### PR TITLE
Rrv feature paginadores uno a varios

### DIFF
--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/Manual.aspx
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/Manual.aspx
@@ -537,123 +537,126 @@
             <td>
                 <asp:UpdatePanel runat="server" ID="upGrvConciliadas" UpdateMode="Always">
                     <ContentTemplate>
-                        <asp:GridView ID="grvConciliadas" runat="server" AutoGenerateColumns="False" AllowPaging="True"
-                            PageSize="5" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
-                            OnPageIndexChanging="grvConciliadas_PageIndexChanging" OnRowDataBound="grvConciliadas_RowDataBound"
-                            DataKeyNames="CorporativoConciliacion, SucursalConciliacion, AñoConciliacion, MesConciliacion, FolioConciliacion, FolioExterno, SecuenciaExterno"
-                            OnRowCommand="grvConciliadas_RowCommand" OnSelectedIndexChanging="grvConciliadas_SelectedIndexChanging"
-                            OnRowCreated="grvConciliadas_RowCreated" AllowSorting="True" OnSorting="grvConciliadas_Sorting">
-                            <EmptyDataTemplate>
-                                <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="No se han conciliado ninguna transacción."></asp:Label>
-                            </EmptyDataTemplate>
-                            <HeaderStyle HorizontalAlign="Center" />
-                            <Columns>
-                                <asp:TemplateField HeaderText="Folio" SortExpression="FolioExterno">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lFolio" runat="server" Text='<%# resaltarBusqueda(Eval("FolioExterno").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ControlStyle CssClass="centradoMedio" />
-                                    <ItemStyle BackColor="#ebecec" ForeColor="Black" HorizontalAlign="Center" Width="50px" />
-                                    <HeaderStyle HorizontalAlign="Center" Width="50px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Sec." SortExpression="SecuenciaExterno">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblSecuencia" runat="server" Text='<%# resaltarBusqueda(Eval("SecuenciaExterno").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ControlStyle CssClass="centradoMedio" />
-                                    <ItemStyle HorizontalAlign="Center" Width="20px" BackColor="#ebecec" ForeColor="Black"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="20px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="F. Mov." SortExpression="FMovimiento">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFMovimiento" runat="server" Text='<%# resaltarBusqueda(Eval("FMovimiento","{0:d}").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ControlStyle CssClass="centradoMedio" />
-                                    <ItemStyle HorizontalAlign="Center"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="F. Op." SortExpression="FOperacion">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFOperacion" runat="server" Text='<%# resaltarBusqueda(Eval("FOperacion","{0:d}").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ControlStyle CssClass="centradoMedio" />
-                                    <ItemStyle HorizontalAlign="Center"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Mont. Conciliado" SortExpression="MontoConciliado">
-                                    <ItemTemplate>
-                                        <b>
-                                            <asp:Label ID="lblDeposito" runat="server" Text='<%# resaltarBusqueda(Eval("MontoConciliado","{0:c2}").ToString()) %>'></asp:Label></b>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Concepto" SortExpression="Concepto">
-                                    <ItemTemplate>
-                                        <div class="parrafoTexto" style="width: 400px">
-                                            <asp:Label ID="lblConceptoExt" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'></asp:Label>
-                                        </div>
-                                        <asp:HoverMenuExtender ID="hmeConceptoExt" runat="server" TargetControlID="lblConceptoExt"
-                                            PopupControlID="pnlPopUpConceptoExt" PopDelay="20" OffsetX="0" OffsetY="0">
-                                        </asp:HoverMenuExtender>
-                                        <asp:Panel ID="pnlPopUpConceptoExt" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                            Width="500px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
-                                            <asp:Label ID="lblToolTipConceptoExt" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'
-                                                CssClass="etiqueta " Font-Size="10px" />
-                                        </asp:Panel>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Justify" Width="400px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="400px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Descripcion" SortExpression="Descripcion">
-                                    <ItemTemplate>
-                                        <div class="parrafoTexto" style="width: 200px">
-                                            <asp:Label ID="lblDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'></asp:Label>
-                                        </div>
-                                        <asp:HoverMenuExtender ID="hmeDescripcionExt" runat="server" TargetControlID="lblConceptoExt"
-                                            PopupControlID="pnlPopUpConceptoExt" PopDelay="20" OffsetX="0" OffsetY="0">
-                                        </asp:HoverMenuExtender>
-                                        <asp:Panel ID="pnlPopUpDescripcionExt" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                            Width="200px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
-                                            <asp:Label ID="lblToolTipDescripcionExt" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'
-                                                CssClass="etiqueta " Font-Size="10px" />
-                                        </asp:Panel>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Justify" Width="200px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="200px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField>
-                                    <ItemTemplate>
-                                        <asp:Button runat="server" ID="imgDesconciliar" CssClass="Desconciliar centradoMedio boton"
-                                            ToolTip="DESCONCILIAR" Width="20px" Height="20px" OnClientClick='<%# "return confirm(\"¿Esta seguro de DESCONCILIAR la Transacción: " + Eval("FolioExterno").ToString() + ": Secuencia: "+ Eval("SecuenciaExterno").ToString() + "?¡Se actualizará la conciliacion y su detalle! ?\");" %>'
-                                            CommandName="DESCONCILIAR" />
-                                        <asp:Button runat="server" ID="imgDetalleConciliado" CssClass="Detalle centradoMedio boton"
-                                            ToolTip="VER DETALLE" Width="20px" Height="20px" CommandName="Select" />
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" Width="80px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="80px"></HeaderStyle>
-                                </asp:TemplateField>
-                            </Columns>
-                            <PagerTemplate>
-                                Página
-                                <asp:DropDownList ID="paginasDropDownListConciliadas" Font-Size="12px" AutoPostBack="true"
-                                    runat="server" OnSelectedIndexChanged="paginasDropDownListConciliadas_SelectedIndexChanged"
-                                    CssClass="dropDown" Width="60px">
-                                </asp:DropDownList>
-                                de
-                                <asp:Label ID="lblTotalNumPaginas" runat="server" CssClass="etiqueta fg-color-blanco" />
-                                &nbsp;&nbsp;
-                                <asp:Button ID="btnInicial" runat="server" CommandName="Page" ToolTip="Prim. Pag"
-                                    CommandArgument="First" CssClass="boton pagInicial" />
-                                <asp:Button ID="btnAnterior" runat="server" CommandName="Page" ToolTip="Pág. anterior"
-                                    CommandArgument="Prev" CssClass="boton pagAnterior" />
-                                <asp:Button ID="btnSiguiente" runat="server" CommandName="Page" ToolTip="Sig. página"
-                                    CommandArgument="Next" CssClass="boton pagSiguiente" />
-                                <asp:Button ID="btnUltima" runat="server" CommandName="Page" ToolTip="Últ. Pag" CommandArgument="Last"
-                                    CssClass="boton pagUltima" />
-                            </PagerTemplate>
-                            <PagerStyle CssClass="estiloPaginacion bg-color-grisOscuro fg-color-blanco" />
-                        </asp:GridView>
+                        <div style="width:1200px; height:250px; overflow:auto;">
+                            <asp:GridView ID="grvConciliadas" runat="server" 
+                                AllowPaging='<%# ActivePaging %>' PageSize="5"
+                                AutoGenerateColumns="False" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
+                                OnPageIndexChanging="grvConciliadas_PageIndexChanging" OnRowDataBound="grvConciliadas_RowDataBound"
+                                DataKeyNames="CorporativoConciliacion, SucursalConciliacion, AñoConciliacion, MesConciliacion, FolioConciliacion, FolioExterno, SecuenciaExterno"
+                                OnRowCommand="grvConciliadas_RowCommand" OnSelectedIndexChanging="grvConciliadas_SelectedIndexChanging"
+                                OnRowCreated="grvConciliadas_RowCreated" AllowSorting="True" OnSorting="grvConciliadas_Sorting">
+                                <EmptyDataTemplate>
+                                    <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="No se han conciliado ninguna transacción."></asp:Label>
+                                </EmptyDataTemplate>
+                                <HeaderStyle HorizontalAlign="Center" />
+                                <Columns>
+                                    <asp:TemplateField HeaderText="Folio" SortExpression="FolioExterno">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lFolio" runat="server" Text='<%# resaltarBusqueda(Eval("FolioExterno").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ControlStyle CssClass="centradoMedio" />
+                                        <ItemStyle BackColor="#ebecec" ForeColor="Black" HorizontalAlign="Center" Width="50px" />
+                                        <HeaderStyle HorizontalAlign="Center" Width="50px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Sec." SortExpression="SecuenciaExterno">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblSecuencia" runat="server" Text='<%# resaltarBusqueda(Eval("SecuenciaExterno").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ControlStyle CssClass="centradoMedio" />
+                                        <ItemStyle HorizontalAlign="Center" Width="20px" BackColor="#ebecec" ForeColor="Black"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="20px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="F. Mov." SortExpression="FMovimiento">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFMovimiento" runat="server" Text='<%# resaltarBusqueda(Eval("FMovimiento","{0:d}").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ControlStyle CssClass="centradoMedio" />
+                                        <ItemStyle HorizontalAlign="Center"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="F. Op." SortExpression="FOperacion">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFOperacion" runat="server" Text='<%# resaltarBusqueda(Eval("FOperacion","{0:d}").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ControlStyle CssClass="centradoMedio" />
+                                        <ItemStyle HorizontalAlign="Center"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Mont. Conciliado" SortExpression="MontoConciliado">
+                                        <ItemTemplate>
+                                            <b>
+                                                <asp:Label ID="lblDeposito" runat="server" Text='<%# resaltarBusqueda(Eval("MontoConciliado","{0:c2}").ToString()) %>'></asp:Label></b>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Concepto" SortExpression="Concepto">
+                                        <ItemTemplate>
+                                            <div class="parrafoTexto" style="width: 400px">
+                                                <asp:Label ID="lblConceptoExt" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'></asp:Label>
+                                            </div>
+                                            <asp:HoverMenuExtender ID="hmeConceptoExt" runat="server" TargetControlID="lblConceptoExt"
+                                                PopupControlID="pnlPopUpConceptoExt" PopDelay="20" OffsetX="0" OffsetY="0">
+                                            </asp:HoverMenuExtender>
+                                            <asp:Panel ID="pnlPopUpConceptoExt" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                Width="500px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
+                                                <asp:Label ID="lblToolTipConceptoExt" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'
+                                                    CssClass="etiqueta " Font-Size="10px" />
+                                            </asp:Panel>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Justify" Width="400px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="400px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Descripcion" SortExpression="Descripcion">
+                                        <ItemTemplate>
+                                            <div class="parrafoTexto" style="width: 200px">
+                                                <asp:Label ID="lblDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'></asp:Label>
+                                            </div>
+                                            <asp:HoverMenuExtender ID="hmeDescripcionExt" runat="server" TargetControlID="lblConceptoExt"
+                                                PopupControlID="pnlPopUpConceptoExt" PopDelay="20" OffsetX="0" OffsetY="0">
+                                            </asp:HoverMenuExtender>
+                                            <asp:Panel ID="pnlPopUpDescripcionExt" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                Width="200px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
+                                                <asp:Label ID="lblToolTipDescripcionExt" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'
+                                                    CssClass="etiqueta " Font-Size="10px" />
+                                            </asp:Panel>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Justify" Width="200px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="200px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField>
+                                        <ItemTemplate>
+                                            <asp:Button runat="server" ID="imgDesconciliar" CssClass="Desconciliar centradoMedio boton"
+                                                ToolTip="DESCONCILIAR" Width="20px" Height="20px" OnClientClick='<%# "return confirm(\"¿Esta seguro de DESCONCILIAR la Transacción: " + Eval("FolioExterno").ToString() + ": Secuencia: "+ Eval("SecuenciaExterno").ToString() + "?¡Se actualizará la conciliacion y su detalle! ?\");" %>'
+                                                CommandName="DESCONCILIAR" />
+                                            <asp:Button runat="server" ID="imgDetalleConciliado" CssClass="Detalle centradoMedio boton"
+                                                ToolTip="VER DETALLE" Width="20px" Height="20px" CommandName="Select" />
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" Width="80px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="80px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                </Columns>
+                                <PagerTemplate>
+                                    Página
+                                    <asp:DropDownList ID="paginasDropDownListConciliadas" Font-Size="12px" AutoPostBack="true"
+                                        runat="server" OnSelectedIndexChanged="paginasDropDownListConciliadas_SelectedIndexChanged"
+                                        CssClass="dropDown" Width="60px">
+                                    </asp:DropDownList>
+                                    de
+                                    <asp:Label ID="lblTotalNumPaginas" runat="server" CssClass="etiqueta fg-color-blanco" />
+                                    &nbsp;&nbsp;
+                                    <asp:Button ID="btnInicial" runat="server" CommandName="Page" ToolTip="Prim. Pag"
+                                        CommandArgument="First" CssClass="boton pagInicial" />
+                                    <asp:Button ID="btnAnterior" runat="server" CommandName="Page" ToolTip="Pág. anterior"
+                                        CommandArgument="Prev" CssClass="boton pagAnterior" />
+                                    <asp:Button ID="btnSiguiente" runat="server" CommandName="Page" ToolTip="Sig. página"
+                                        CommandArgument="Next" CssClass="boton pagSiguiente" />
+                                    <asp:Button ID="btnUltima" runat="server" CommandName="Page" ToolTip="Últ. Pag" CommandArgument="Last"
+                                        CssClass="boton pagUltima" />
+                                </PagerTemplate>
+                                <PagerStyle CssClass="estiloPaginacion bg-color-grisOscuro fg-color-blanco" />
+                            </asp:GridView>
+                        </div>
                     </ContentTemplate>
                 </asp:UpdatePanel>
             </td>
@@ -775,127 +778,125 @@
 	                        </table>
                         </div>
                         <div style="height:500px; width:590px; overflow:auto;">                            
-                        <asp:GridView ID="grvExternos" runat="server" AutoGenerateColumns="False" ViewStateMode="Enabled"
-                            OnRowDataBound="grvExternos_RowDataBound" ShowHeaderWhenEmpty="True" Width="100%"
-                            DataKeyNames="Secuencia,Folio" AllowSorting="True" CssClass="grvResultadoConsultaCss"
-                            OnSorting="grvExternos_Sorting" OnPageIndexChanging="grvExternos_PageIndexChanging">
-                            <%--<EmptyDataTemplate>
-                                    <asp:Label ID="lblvacio" runat="server" Font-Bold="True" Font-Overline="False" ForeColor="#CC3300"
-                                        Text="No se encontraron referencias externas."></asp:Label>
-                                </EmptyDataTemplate>--%>
-                            <HeaderStyle HorizontalAlign="Center" />
-                            <RowStyle CssClass="bg-color-blanco fg-color-negro" />
-                            <Columns>
-                                <asp:TemplateField>
-                                    <ItemTemplate>
-                                        <asp:CheckBox runat="server" ID="chkExterno" 
-                                            OnClick='<%# String.Concat("chkExterno_clic(this,", Eval("Deposito"), ",", Eval("Retiro"), ");") %>'
-                                            OnCheckedChanged="chkExterno_CheckedChanged"
-                                            AutoPostBack="False" Checked='<%# Bind("Selecciona") %>' />
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" Width="30px" BackColor="#ebecec"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="30px" />
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Secuencia" SortExpression="Secuencia">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblSecuencia" runat="server" Text='<%# resaltarBusqueda(Eval("Secuencia").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" BackColor="#ebecec" Width="80px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="80px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Status" SortExpression="StatusConciliacion">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblStatusConciliacion" runat="server" Text='<%# Bind("StatusConciliacion") %>'
-                                            Style="display: none"></asp:Label>
-                                        <asp:Image runat="server" ID="imgStatusConciliacion" ImageUrl='<%# Bind("UbicacionIcono") %>'
-                                            Width="25px" Height="25px" CssClass="icono border-color-grisOscuro centradoMedio"
-                                            ToolTip='<%# Bind("StatusConciliacion") %>' AlternateText='<%# Bind("StatusConciliacion") %>' />
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" BackColor="#ebecec" Width="35px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="35px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="FolioExt" SortExpression="Folio">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFolio" runat="server" Text='<%# resaltarBusqueda(Eval("Folio").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="FMovimiento" SortExpression="FMovimiento">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFMovimiento" runat="server" Text='<%# resaltarBusqueda(Eval("FMovimiento","{0:d}").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="FOperacion" SortExpression="FOperacion">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFOperacion" runat="server" Text='<%# resaltarBusqueda(Eval("FOperacion","{0:d}").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Documento" SortExpression="Referencia">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblReferencia" runat="server" Text='<%# resaltarBusqueda(Eval("Referencia").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="120px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="120px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Retiro" SortExpression="Retiro">
-                                    <ItemTemplate>
-                                        <b>
-                                            <asp:Label ID="lblRetiro" runat="server" Text='<%# resaltarBusqueda(Eval("Retiro","{0:c2}").ToString()) %>'></asp:Label></b>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Deposito" SortExpression="Deposito">
-                                    <ItemTemplate>
-                                        <b>
-                                            <asp:Label ID="lblDeposito" runat="server" Text='<%# resaltarBusqueda(Eval("Deposito","{0:c2}").ToString()) %>'></asp:Label></b>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Concepto" SortExpression="Concepto">
-                                    <ItemTemplate>
-                                        <div class="parrafoTexto">
-                                            <asp:Label ID="lblConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'></asp:Label>
-                                        </div>
-                                        <asp:HoverMenuExtender ID="hmeConcepto" runat="server" TargetControlID="lblConcepto"
-                                            PopupControlID="pnlPopUpConcepto" PopDelay="20" OffsetX="-70" OffsetY="-10">
-                                        </asp:HoverMenuExtender>
-                                        <asp:Panel ID="pnlPopUpConcepto" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                            Width="250px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
-                                            <asp:Label ID="lblToolTipConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'
-                                                CssClass="etiqueta " Font-Size="10px" />
-                                        </asp:Panel>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Justify" Width="150px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="150px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Descripcion" SortExpression="Descripcion">
-                                    <ItemTemplate>
-                                        <div class="parrafoTexto">
-                                            <asp:Label ID="lblDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'></asp:Label>
-                                        </div>
-                                        <asp:HoverMenuExtender ID="hmeDescripcion" runat="server" TargetControlID="lblDescripcion"
-                                            PopupControlID="pnlPopUpDescripcion" PopDelay="20" OffsetX="-30" OffsetY="-10">
-                                        </asp:HoverMenuExtender>
-                                        <asp:Panel ID="pnlPopUpDescripcion" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                            Width="150px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
-                                            <asp:Label ID="lblToolTipDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'
-                                                CssClass="etiqueta " Font-Size="10px" />
-                                        </asp:Panel>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Justify" Width="150px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="150px"></HeaderStyle>
-                                </asp:TemplateField>
-                            </Columns>
-                            <SelectedRowStyle BackColor="#66CCFF" ForeColor="Black" />
-                            <PagerStyle CssClass="grvPaginacionScroll" />
-                        </asp:GridView>
+                            <asp:GridView ID="grvExternos" runat="server" 
+                                AllowPaging='<%# ActivePaging %>' PageSize="10" 
+                                AutoGenerateColumns="False" ViewStateMode="Enabled"
+                                OnRowDataBound="grvExternos_RowDataBound" ShowHeaderWhenEmpty="True" Width="100%"
+                                DataKeyNames="Secuencia,Folio" AllowSorting="True" CssClass="grvResultadoConsultaCss"
+                                OnSorting="grvExternos_Sorting" OnPageIndexChanging="grvExternos_PageIndexChanging">
+                                <HeaderStyle HorizontalAlign="Center" />
+                                <RowStyle CssClass="bg-color-blanco fg-color-negro" />
+                                <Columns>
+                                    <asp:TemplateField>
+                                        <ItemTemplate>
+                                            <asp:CheckBox runat="server" ID="chkExterno" 
+                                                OnClick='<%# String.Concat("chkExterno_clic(this,", Eval("Deposito"), ",", Eval("Retiro"), ");") %>'
+                                                OnCheckedChanged="chkExterno_CheckedChanged"
+                                                AutoPostBack="False" Checked='<%# Bind("Selecciona") %>' />
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" Width="30px" BackColor="#ebecec"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="30px" />
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Secuencia" SortExpression="Secuencia">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblSecuencia" runat="server" Text='<%# resaltarBusqueda(Eval("Secuencia").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" BackColor="#ebecec" Width="80px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="80px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Status" SortExpression="StatusConciliacion">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblStatusConciliacion" runat="server" Text='<%# Bind("StatusConciliacion") %>'
+                                                Style="display: none"></asp:Label>
+                                            <asp:Image runat="server" ID="imgStatusConciliacion" ImageUrl='<%# Bind("UbicacionIcono") %>'
+                                                Width="25px" Height="25px" CssClass="icono border-color-grisOscuro centradoMedio"
+                                                ToolTip='<%# Bind("StatusConciliacion") %>' AlternateText='<%# Bind("StatusConciliacion") %>' />
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" BackColor="#ebecec" Width="35px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="35px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="FolioExt" SortExpression="Folio">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFolio" runat="server" Text='<%# resaltarBusqueda(Eval("Folio").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="FMovimiento" SortExpression="FMovimiento">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFMovimiento" runat="server" Text='<%# resaltarBusqueda(Eval("FMovimiento","{0:d}").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="FOperacion" SortExpression="FOperacion">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFOperacion" runat="server" Text='<%# resaltarBusqueda(Eval("FOperacion","{0:d}").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Documento" SortExpression="Referencia">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblReferencia" runat="server" Text='<%# resaltarBusqueda(Eval("Referencia").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="120px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="120px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Retiro" SortExpression="Retiro">
+                                        <ItemTemplate>
+                                            <b>
+                                                <asp:Label ID="lblRetiro" runat="server" Text='<%# resaltarBusqueda(Eval("Retiro","{0:c2}").ToString()) %>'></asp:Label></b>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Deposito" SortExpression="Deposito">
+                                        <ItemTemplate>
+                                            <b>
+                                                <asp:Label ID="lblDeposito" runat="server" Text='<%# resaltarBusqueda(Eval("Deposito","{0:c2}").ToString()) %>'></asp:Label></b>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Concepto" SortExpression="Concepto">
+                                        <ItemTemplate>
+                                            <div class="parrafoTexto">
+                                                <asp:Label ID="lblConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'></asp:Label>
+                                            </div>
+                                            <asp:HoverMenuExtender ID="hmeConcepto" runat="server" TargetControlID="lblConcepto"
+                                                PopupControlID="pnlPopUpConcepto" PopDelay="20" OffsetX="-70" OffsetY="-10">
+                                            </asp:HoverMenuExtender>
+                                            <asp:Panel ID="pnlPopUpConcepto" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                Width="250px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
+                                                <asp:Label ID="lblToolTipConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'
+                                                    CssClass="etiqueta " Font-Size="10px" />
+                                            </asp:Panel>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Justify" Width="150px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="150px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Descripcion" SortExpression="Descripcion">
+                                        <ItemTemplate>
+                                            <div class="parrafoTexto">
+                                                <asp:Label ID="lblDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'></asp:Label>
+                                            </div>
+                                            <asp:HoverMenuExtender ID="hmeDescripcion" runat="server" TargetControlID="lblDescripcion"
+                                                PopupControlID="pnlPopUpDescripcion" PopDelay="20" OffsetX="-30" OffsetY="-10">
+                                            </asp:HoverMenuExtender>
+                                            <asp:Panel ID="pnlPopUpDescripcion" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                Width="150px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
+                                                <asp:Label ID="lblToolTipDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'
+                                                    CssClass="etiqueta " Font-Size="10px" />
+                                            </asp:Panel>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Justify" Width="150px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="150px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                </Columns>
+                                <SelectedRowStyle BackColor="#66CCFF" ForeColor="Black" />
+                                <PagerStyle CssClass="grvPaginacionScroll" />
+                            </asp:GridView>
                         </div>
                         <asp:HiddenField ID="hfExternosSV" runat="server" />
                         <asp:HiddenField ID="hfExternosSH" runat="server" />
@@ -1039,136 +1040,136 @@
 	                        </table>
                         </div>
                         <div style="height:500px; width:590px; overflow:auto;">
-                        <asp:GridView ID="grvInternos" runat="server" AutoGenerateColumns="False" ShowHeader="True"
-                            CssClass="grvResultadoConsultaCss" AllowSorting="True"
-                            OnRowDataBound="grvInternos_RowDataBound" 
-                            Width="100%" DataKeyNames="Secuencia, Folio, Sucursal" 
-
-                            ShowHeaderWhenEmpty="True" ShowFooter="False"
-                            OnSorting="grvInternos_Sorting" 
-                            OnPageIndexChanging="grvInternos_PageIndexChanging">
-                            <HeaderStyle HorizontalAlign="Center" />
-                            <Columns>
-                                <asp:TemplateField>
-                                    <ItemTemplate>
-                                        <asp:CheckBox runat="server" ID="chkInterno"
-                                            Checked='<%# Bind("Selecciona") %>' 
-                                            OnClick='<%# String.Concat("chkInterno_clic(this,", Eval("Deposito"), ",", Eval("Retiro"),");") %>'
-                                            AutoPostBack="False" 
-                                            OnCheckedChanged="chkInterno_CheckedChanged"
-                                            />
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" VerticalAlign="Middle" Width="20px" BackColor="#ebecec"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="20px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Secuencia" SortExpression="Secuencia">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblSecuenciaIn" runat="server" Text='<%# resaltarBusqueda(Eval("Secuencia").ToString()) %>' />
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Wrap="True" BackColor="#ebecec"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Wrap="True"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Status" SortExpression="StatusConciliacion">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblStatusConciliacion" runat="server" Text='<%# Bind("StatusConciliacion") %>'
-                                            Style="display: none"></asp:Label>
-                                        <asp:Image runat="server" ID="imgStatusConciliacion" ImageUrl='<%# Bind("UbicacionIcono") %>'
-                                            Width="25px" Height="25px" CssClass="icono border-color-grisOscuro centradoMedio"
-                                            ToolTip='<%# Bind("StatusConciliacion") %>' AlternateText='<%# Bind("StatusConciliacion") %>' />
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" BackColor="#ebecec"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Folio" SortExpression="Folio">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFolioIn" runat="server" Text='<%# resaltarBusqueda(Eval("Folio").ToString()) %>' />
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" BackColor="#ebecec"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="FMovimiento" SortExpression="FMovimiento">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFMovimiento" runat="server" Text='<%# resaltarBusqueda(Eval("FMovimiento","{0:d}").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="FOperacion" SortExpression="FOperacion">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblFOperacion" runat="server" Text='<%# resaltarBusqueda(Eval("FOperacion","{0:d}").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Documento" SortExpression="Referencia">
-                                    <ItemTemplate>
-                                        <asp:Label ID="lblReferencia" runat="server" Text='<%# resaltarBusqueda(Eval("Referencia").ToString()) %>'></asp:Label>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Retiro" SortExpression="Retiro">
-                                    <ItemTemplate>
-                                        <b>
-                                            <asp:Label ID="lblRetiro" runat="server" Text='<%# resaltarBusqueda(Eval("Retiro","{0:c2}").ToString()) %>'></asp:Label></b>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Deposito" SortExpression="Deposito">
-                                    <ItemTemplate>
-                                        <b>
-                                            <asp:Label ID="lblDeposito" runat="server" Text='<%# resaltarBusqueda(Eval("Deposito","{0:c2}").ToString()) %>'></asp:Label></b>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Concepto" SortExpression="Concepto">
-                                    <ItemTemplate>
-                                        <div class="parrafoTexto">
-                                            <asp:Label ID="lblConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'></asp:Label>
-                                        </div>
-                                        <asp:HoverMenuExtender ID="hmeConcepto" runat="server" TargetControlID="lblConcepto"
-                                            PopupControlID="pnlPopUpConcepto" PopDelay="20" OffsetX="-30" OffsetY="0">
-                                        </asp:HoverMenuExtender>
-                                        <asp:Panel ID="pnlPopUpConcepto" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                            Width="150px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
-                                            <asp:Label ID="lblToolTipConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'
-                                                CssClass="etiqueta " Font-Size="10px" />
-                                        </asp:Panel>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Justify"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                                <asp:TemplateField HeaderText="Descripcion" SortExpression="Descripcion">
-                                    <ItemTemplate>
-                                        <div class="parrafoTexto">
-                                            <asp:Label ID="lblDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'></asp:Label>
-                                        </div>
-                                        <asp:HoverMenuExtender ID="hmeDescripcion" runat="server" TargetControlID="lblDescripcion"
-                                            PopupControlID="pnlPopUpDescripcion" PopDelay="20" OffsetX="-30" OffsetY="0">
-                                        </asp:HoverMenuExtender>
-                                        <asp:Panel ID="pnlPopUpDescripcion" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                            Width="150px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
-                                            <asp:Label ID="lblToolTipDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'
-                                                CssClass="etiqueta " Font-Size="10px" />
-                                        </asp:Panel>
-                                    </ItemTemplate>
-                                    <ItemStyle HorizontalAlign="Justify"></ItemStyle>
-                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                </asp:TemplateField>
-                            </Columns>
-                            <PagerStyle CssClass="grvPaginacionScroll" />
-                        </asp:GridView>
+                            <asp:GridView ID="grvInternos" runat="server" 
+                                AllowPaging='<%# ActivePaging %>' PageSize="10"
+                                AutoGenerateColumns="False" ShowHeader="True"
+                                CssClass="grvResultadoConsultaCss" AllowSorting="True"
+                                OnRowDataBound="grvInternos_RowDataBound" 
+                                Width="100%" DataKeyNames="Secuencia, Folio, Sucursal" 
+                                ShowHeaderWhenEmpty="True" ShowFooter="False"
+                                OnSorting="grvInternos_Sorting" 
+                                OnPageIndexChanging="grvInternos_PageIndexChanging">
+                                <HeaderStyle HorizontalAlign="Center" />
+                                <Columns>
+                                    <asp:TemplateField>
+                                        <ItemTemplate>
+                                            <asp:CheckBox runat="server" ID="chkInterno"
+                                                Checked='<%# Bind("Selecciona") %>' 
+                                                OnClick='<%# String.Concat("chkInterno_clic(this,", Eval("Deposito"), ",", Eval("Retiro"),");") %>'
+                                                AutoPostBack="False" 
+                                                OnCheckedChanged="chkInterno_CheckedChanged"
+                                                />
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" VerticalAlign="Middle" Width="20px" BackColor="#ebecec"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="20px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Secuencia" SortExpression="Secuencia">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblSecuenciaIn" runat="server" Text='<%# resaltarBusqueda(Eval("Secuencia").ToString()) %>' />
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Wrap="True" BackColor="#ebecec"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Wrap="True"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Status" SortExpression="StatusConciliacion">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblStatusConciliacion" runat="server" Text='<%# Bind("StatusConciliacion") %>'
+                                                Style="display: none"></asp:Label>
+                                            <asp:Image runat="server" ID="imgStatusConciliacion" ImageUrl='<%# Bind("UbicacionIcono") %>'
+                                                Width="25px" Height="25px" CssClass="icono border-color-grisOscuro centradoMedio"
+                                                ToolTip='<%# Bind("StatusConciliacion") %>' AlternateText='<%# Bind("StatusConciliacion") %>' />
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" BackColor="#ebecec"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Folio" SortExpression="Folio">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFolioIn" runat="server" Text='<%# resaltarBusqueda(Eval("Folio").ToString()) %>' />
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" BackColor="#ebecec"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="FMovimiento" SortExpression="FMovimiento">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFMovimiento" runat="server" Text='<%# resaltarBusqueda(Eval("FMovimiento","{0:d}").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="FOperacion" SortExpression="FOperacion">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblFOperacion" runat="server" Text='<%# resaltarBusqueda(Eval("FOperacion","{0:d}").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Documento" SortExpression="Referencia">
+                                        <ItemTemplate>
+                                            <asp:Label ID="lblReferencia" runat="server" Text='<%# resaltarBusqueda(Eval("Referencia").ToString()) %>'></asp:Label>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Retiro" SortExpression="Retiro">
+                                        <ItemTemplate>
+                                            <b>
+                                                <asp:Label ID="lblRetiro" runat="server" Text='<%# resaltarBusqueda(Eval("Retiro","{0:c2}").ToString()) %>'></asp:Label></b>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Deposito" SortExpression="Deposito">
+                                        <ItemTemplate>
+                                            <b>
+                                                <asp:Label ID="lblDeposito" runat="server" Text='<%# resaltarBusqueda(Eval("Deposito","{0:c2}").ToString()) %>'></asp:Label></b>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Concepto" SortExpression="Concepto">
+                                        <ItemTemplate>
+                                            <div class="parrafoTexto">
+                                                <asp:Label ID="lblConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'></asp:Label>
+                                            </div>
+                                            <asp:HoverMenuExtender ID="hmeConcepto" runat="server" TargetControlID="lblConcepto"
+                                                PopupControlID="pnlPopUpConcepto" PopDelay="20" OffsetX="-30" OffsetY="0">
+                                            </asp:HoverMenuExtender>
+                                            <asp:Panel ID="pnlPopUpConcepto" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                Width="150px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
+                                                <asp:Label ID="lblToolTipConcepto" runat="server" Text='<%# resaltarBusqueda(Eval("Concepto").ToString()) %>'
+                                                    CssClass="etiqueta " Font-Size="10px" />
+                                            </asp:Panel>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Justify"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                    <asp:TemplateField HeaderText="Descripcion" SortExpression="Descripcion">
+                                        <ItemTemplate>
+                                            <div class="parrafoTexto">
+                                                <asp:Label ID="lblDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'></asp:Label>
+                                            </div>
+                                            <asp:HoverMenuExtender ID="hmeDescripcion" runat="server" TargetControlID="lblDescripcion"
+                                                PopupControlID="pnlPopUpDescripcion" PopDelay="20" OffsetX="-30" OffsetY="0">
+                                            </asp:HoverMenuExtender>
+                                            <asp:Panel ID="pnlPopUpDescripcion" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                Width="150px" Style="padding: 5px 5px 5px 5px" BackColor="White" Wrap="True">
+                                                <asp:Label ID="lblToolTipDescripcion" runat="server" Text='<%# resaltarBusqueda(Eval("Descripcion").ToString()) %>'
+                                                    CssClass="etiqueta " Font-Size="10px" />
+                                            </asp:Panel>
+                                        </ItemTemplate>
+                                        <ItemStyle HorizontalAlign="Justify"></ItemStyle>
+                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                    </asp:TemplateField>
+                                </Columns>
+                                <PagerStyle CssClass="grvPaginacionScroll" />
+                            </asp:GridView>
                         </div>
-                        <asp:GridView ID="grvPedidos" runat="server" AutoGenerateColumns="False" ShowHeader="True"
+                        <asp:GridView ID="grvPedidos" runat="server" 
+                            AllowPaging='<%# ActivePaging %>' PageSize="10" 
+                            AutoGenerateColumns="False" ShowHeader="True"
                             CssClass="grvResultadoConsultaCss" AllowSorting="True" ShowFooter="False" Width="100%"
                             ShowHeaderWhenEmpty="True" DataKeyNames="Celula,Pedido,AñoPed,Cliente" OnSorting="grvPedidos_Sorting"
-                            AllowPaging="True" PageSize="100" OnPageIndexChanging="grvPedidos_PageIndexChanging"
+                            OnPageIndexChanging="grvPedidos_PageIndexChanging"
                             OnRowDataBound="grvPedidos_RowDataBound">
-                            <%-- <EmptyDataTemplate>
-                                <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="No se encontraron información sobre pedidos."></asp:Label>
-                            </EmptyDataTemplate>--%>
                             <HeaderStyle HorizontalAlign="Center" />
                             <Columns>
                                 <asp:TemplateField>
@@ -1319,149 +1320,158 @@
                         </td>
                     </tr>
                     <tr>
-                        <td style="padding: 5px 5px 5px 5px; width: 100%">
-                            <asp:GridView ID="grvDetalleArchivoInterno" runat="server" AutoGenerateColumns="False"
-                                ShowHeader="True" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
-                                ShowFooter="False" DataKeyNames="SecuenciaInterno, FolioInterno">
-                                <EmptyDataTemplate>
-                                    <asp:Label ID="lblvacio" runat="server" Font-Bold="True" Font-Overline="False" ForeColor="#CC3300"
-                                        Text="No se encontraron referencias internas"></asp:Label>
-                                </EmptyDataTemplate>
-                                <HeaderStyle HorizontalAlign="Center" />
-                                <Columns>
-                                    <asp:TemplateField>
-                                        <ItemTemplate>
-                                            <asp:Image ID="img" runat="server" CssClass="icono" Height="15px" ImageUrl="~/App_Themes/GasMetropolitanoSkin/Iconos/Exito.png"
-                                                Width="15px"></asp:Image>
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Center" CssClass="bg-color-verdeClaro centradoMedio"
-                                            Width="20px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="20px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Secuencia" SortExpression="secuenciaInt">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblSecuenciaInt" runat="server" Text='<%# Bind("SecuenciaInterno") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <ControlStyle CssClass="centradoMedio" />
-                                        <ItemStyle HorizontalAlign="Center" BackColor="#ebecec" Width="50px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="50px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Folio" SortExpression="folioInterno">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblFolioInterno" runat="server" Text='<%# Bind("FolioInterno") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <ControlStyle CssClass="centradoMedio" />
-                                        <ItemStyle HorizontalAlign="Center" BackColor="#ebecec" Width="100px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="FMovimiento" SortExpression="fMovimiento">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblFMovimiento" runat="server" Text='<%# Bind("FMovimientoInt","{0:d}") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <ControlStyle CssClass="centradoMedio" />
-                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="FOperacion" SortExpression="fOperacion">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblFOperacion" runat="server" Text='<%# Bind("FOperacionInt","{0:d}") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <ControlStyle CssClass="centradoMedio" />
-                                        <ItemStyle HorizontalAlign="Center"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Monto" SortExpression="monto">
-                                        <ItemTemplate>
-                                            <b>
-                                                <asp:Label ID="lblMonto" runat="server" Text='<%# Bind("MontoInterno","{0:c2}") %>'></asp:Label></b>
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Concepto" SortExpression="concepto">
-                                        <ItemTemplate>
-                                            <div class="parrafoTexto" style="width: 500px">
-                                                <asp:Label ID="lblConceptoInt" runat="server" Text='<%# Bind("ConceptoInterno") %>'></asp:Label>
-                                            </div>
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Center" Width="500px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="500px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                </Columns>
-                            </asp:GridView>
-                            <asp:GridView ID="grvDetallePedidoInterno" runat="server" AutoGenerateColumns="False"
-                                ShowHeader="True" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
-                                DataKeyNames="Celula,Pedido,AñoPed">
-                                <HeaderStyle HorizontalAlign="Center" />
-                                <Columns>
-                                    <asp:TemplateField>
-                                        <ItemTemplate>
-                                            <asp:Image ID="img" runat="server" CssClass="icono" Height="15px" ImageUrl="~/App_Themes/GasMetropolitanoSkin/Iconos/Exito.png"
-                                                Width="15px"></asp:Image>
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Center" CssClass="bg-color-verdeClaro centradoMedio"
-                                            Width="30px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="30px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Ped." SortExpression="Pedido">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblPedido" runat="server" Text='<%# Eval("Pedido") %>' />
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Center" BackColor="#d9b335" ForeColor="White" Width="50px">
-                                        </ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="50px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Celula" SortExpression="Celula">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblCelula" runat="server" Text='<%# Eval("Celula") %>' />
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Center" Width="40px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="40px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Total Pedido" SortExpression="Total">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblMontoPedido" runat="server" Text='<%# Eval("Total","{0:c2}") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                    <%--                                    <asp:TemplateField HeaderText="Concepto" SortExpression="ConceptoPedido">
-                                        <ItemTemplate>
-                                            <div class="parrafoTexto" style="width: 350px">
-                                                <asp:Label ID="lblConceptoPedido" runat="server" Text='<%# Eval("ConceptoPedido") %>'></asp:Label>
-                                            </div>
-                                            <asp:HoverMenuExtender ID="hmeConceptoPedido" runat="server" TargetControlID="lblConceptoPedido"
-                                                PopupControlID="pnlPopUpConceptoPedido" PopDelay="20" OffsetX="-20" OffsetY="-10">
-                                            </asp:HoverMenuExtender>
-                                            <asp:Panel ID="pnlPopUpConceptoPedido" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                                Width="400px" Wrap="True" BackColor="White" Style="padding: 5px 5px 5px 5px">
-                                                <asp:Label ID="lblToolTipConceptoPedido" runat="server" Text='<%# Eval("ConceptoPedido") %>'
-                                                    CssClass="etiqueta" Font-Size="10px" />
-                                            </asp:Panel>
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Justify" Width="400px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="400px"></HeaderStyle>
-                                    </asp:TemplateField>--%>
-                                    <asp:TemplateField HeaderText="Nom. Cliente" SortExpression="Nombre">
-                                        <ItemTemplate>
-                                            <div class="parrafoTexto" style="width: 350px">
-                                                <asp:Label ID="lblCliente" runat="server" Text='<%# Eval("Nombre") %>'></asp:Label>
-                                            </div>
-                                            <asp:HoverMenuExtender ID="hmeCliente" runat="server" TargetControlID="lblCliente"
-                                                PopupControlID="pnlPopUpCliente" PopDelay="20" OffsetX="-20" OffsetY="-10">
-                                            </asp:HoverMenuExtender>
-                                            <asp:Panel ID="pnlPopUpCliente" runat="server" CssClass="grvResultadoConsultaCss ocultar"
-                                                Width="300px" Wrap="True" BackColor="White" Style="padding: 5px 5px 5px 5px">
-                                                <asp:Label ID="lblToolTipCliente" runat="server" Text='<%# Eval("Nombre") %>' CssClass="etiqueta"
-                                                    Font-Size="10px" />
-                                            </asp:Panel>
-                                        </ItemTemplate>
-                                        <ItemStyle HorizontalAlign="Justify" Width="550px"></ItemStyle>
-                                        <HeaderStyle HorizontalAlign="Center" Width="550px"></HeaderStyle>
-                                    </asp:TemplateField>
-                                </Columns>
-                            </asp:GridView>
-                        </td>
+                        <asp:UpdatePanel runat="server">
+                            <ContentTemplate>
+                                <td style="padding: 5px 5px 5px 5px; width: 100%">
+                                    <div style="width:1000px; height:240px; overflow:auto;">
+                                        <asp:GridView ID="grvDetalleArchivoInterno" runat="server" 
+                                            AllowPaging='<%# ActivePaging %>' PageSize="5"
+                                            AutoGenerateColumns="False" ShowHeader="True" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
+                                            ShowFooter="False" DataKeyNames="SecuenciaInterno, FolioInterno"
+                                            OnPageIndexChanging="grvDetalleArchivoInterno_PageIndexChanging" >
+                                            <EmptyDataTemplate>
+                                                <asp:Label ID="lblvacio" runat="server" Font-Bold="True" Font-Overline="False" ForeColor="#CC3300"
+                                                    Text="No se encontraron referencias internas"></asp:Label>
+                                            </EmptyDataTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <Columns>
+                                                <asp:TemplateField>
+                                                    <ItemTemplate>
+                                                        <asp:Image ID="img" runat="server" CssClass="icono" Height="15px" ImageUrl="~/App_Themes/GasMetropolitanoSkin/Iconos/Exito.png"
+                                                            Width="15px"></asp:Image>
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Center" CssClass="bg-color-verdeClaro centradoMedio"
+                                                        Width="20px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="20px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="Secuencia" SortExpression="secuenciaInt">
+                                                    <ItemTemplate>
+                                                        <asp:Label ID="lblSecuenciaInt" runat="server" Text='<%# Bind("SecuenciaInterno") %>'></asp:Label>
+                                                    </ItemTemplate>
+                                                    <ControlStyle CssClass="centradoMedio" />
+                                                    <ItemStyle HorizontalAlign="Center" BackColor="#ebecec" Width="50px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="50px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="Folio" SortExpression="folioInterno">
+                                                    <ItemTemplate>
+                                                        <asp:Label ID="lblFolioInterno" runat="server" Text='<%# Bind("FolioInterno") %>'></asp:Label>
+                                                    </ItemTemplate>
+                                                    <ControlStyle CssClass="centradoMedio" />
+                                                    <ItemStyle HorizontalAlign="Center" BackColor="#ebecec" Width="100px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="FMovimiento" SortExpression="fMovimiento">
+                                                    <ItemTemplate>
+                                                        <asp:Label ID="lblFMovimiento" runat="server" Text='<%# Bind("FMovimientoInt","{0:d}") %>'></asp:Label>
+                                                    </ItemTemplate>
+                                                    <ControlStyle CssClass="centradoMedio" />
+                                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="FOperacion" SortExpression="fOperacion">
+                                                    <ItemTemplate>
+                                                        <asp:Label ID="lblFOperacion" runat="server" Text='<%# Bind("FOperacionInt","{0:d}") %>'></asp:Label>
+                                                    </ItemTemplate>
+                                                    <ControlStyle CssClass="centradoMedio" />
+                                                    <ItemStyle HorizontalAlign="Center"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="Monto" SortExpression="monto">
+                                                    <ItemTemplate>
+                                                        <b>
+                                                            <asp:Label ID="lblMonto" runat="server" Text='<%# Bind("MontoInterno","{0:c2}") %>'></asp:Label></b>
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="Concepto" SortExpression="concepto">
+                                                    <ItemTemplate>
+                                                        <div class="parrafoTexto" style="width: 500px">
+                                                            <asp:Label ID="lblConceptoInt" runat="server" Text='<%# Bind("ConceptoInterno") %>'></asp:Label>
+                                                        </div>
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Center" Width="500px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="500px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                            </Columns>
+                                        </asp:GridView>
+                                        <asp:GridView ID="grvDetallePedidoInterno" runat="server" 
+                                            AllowPaging='<%# ActivePaging %>' PageSize="5"
+                                            AutoGenerateColumns="False" ShowHeader="True" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
+                                            DataKeyNames="Celula,Pedido,AñoPed">
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <Columns>
+                                                <asp:TemplateField>
+                                                    <ItemTemplate>
+                                                        <asp:Image ID="img" runat="server" CssClass="icono" Height="15px" ImageUrl="~/App_Themes/GasMetropolitanoSkin/Iconos/Exito.png"
+                                                            Width="15px"></asp:Image>
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Center" CssClass="bg-color-verdeClaro centradoMedio"
+                                                        Width="30px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="30px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="Ped." SortExpression="Pedido">
+                                                    <ItemTemplate>
+                                                        <asp:Label ID="lblPedido" runat="server" Text='<%# Eval("Pedido") %>' />
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Center" BackColor="#d9b335" ForeColor="White" Width="50px">
+                                                    </ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="50px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="Celula" SortExpression="Celula">
+                                                    <ItemTemplate>
+                                                        <asp:Label ID="lblCelula" runat="server" Text='<%# Eval("Celula") %>' />
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Center" Width="40px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="40px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <asp:TemplateField HeaderText="Total Pedido" SortExpression="Total">
+                                                    <ItemTemplate>
+                                                        <asp:Label ID="lblMontoPedido" runat="server" Text='<%# Eval("Total","{0:c2}") %>'></asp:Label>
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Center" Width="100px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="100px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                                <%--                                    <asp:TemplateField HeaderText="Concepto" SortExpression="ConceptoPedido">
+                                                    <ItemTemplate>
+                                                        <div class="parrafoTexto" style="width: 350px">
+                                                            <asp:Label ID="lblConceptoPedido" runat="server" Text='<%# Eval("ConceptoPedido") %>'></asp:Label>
+                                                        </div>
+                                                        <asp:HoverMenuExtender ID="hmeConceptoPedido" runat="server" TargetControlID="lblConceptoPedido"
+                                                            PopupControlID="pnlPopUpConceptoPedido" PopDelay="20" OffsetX="-20" OffsetY="-10">
+                                                        </asp:HoverMenuExtender>
+                                                        <asp:Panel ID="pnlPopUpConceptoPedido" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                            Width="400px" Wrap="True" BackColor="White" Style="padding: 5px 5px 5px 5px">
+                                                            <asp:Label ID="lblToolTipConceptoPedido" runat="server" Text='<%# Eval("ConceptoPedido") %>'
+                                                                CssClass="etiqueta" Font-Size="10px" />
+                                                        </asp:Panel>
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Justify" Width="400px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="400px"></HeaderStyle>
+                                                </asp:TemplateField>--%>
+                                                <asp:TemplateField HeaderText="Nom. Cliente" SortExpression="Nombre">
+                                                    <ItemTemplate>
+                                                        <div class="parrafoTexto" style="width: 350px">
+                                                            <asp:Label ID="lblCliente" runat="server" Text='<%# Eval("Nombre") %>'></asp:Label>
+                                                        </div>
+                                                        <asp:HoverMenuExtender ID="hmeCliente" runat="server" TargetControlID="lblCliente"
+                                                            PopupControlID="pnlPopUpCliente" PopDelay="20" OffsetX="-20" OffsetY="-10">
+                                                        </asp:HoverMenuExtender>
+                                                        <asp:Panel ID="pnlPopUpCliente" runat="server" CssClass="grvResultadoConsultaCss ocultar"
+                                                            Width="300px" Wrap="True" BackColor="White" Style="padding: 5px 5px 5px 5px">
+                                                            <asp:Label ID="lblToolTipCliente" runat="server" Text='<%# Eval("Nombre") %>' CssClass="etiqueta"
+                                                                Font-Size="10px" />
+                                                        </asp:Panel>
+                                                    </ItemTemplate>
+                                                    <ItemStyle HorizontalAlign="Justify" Width="550px"></ItemStyle>
+                                                    <HeaderStyle HorizontalAlign="Center" Width="550px"></HeaderStyle>
+                                                </asp:TemplateField>
+                                            </Columns>
+                                        </asp:GridView>
+                                    </div>
+                                </td>
+                            </ContentTemplate>
+                        </asp:UpdatePanel>
                     </tr>
                     <tr>
                         <td colspan="5" class="bg-color-grisClaro01">
@@ -1700,8 +1710,9 @@
                             <div class="etiqueta">
                                 Folios Agregados
                             </div>
-                            <asp:GridView ID="grvAgregados" runat="server" AllowPaging="True" AutoGenerateColumns="False"
-                                BorderStyle="Dotted" CssClass="grvResultadoConsultaCss" Font-Size="12px" ShowHeaderWhenEmpty="True"
+                            <asp:GridView ID="grvAgregados" runat="server" 
+                                AllowPaging='<%# ActivePaging %>' 
+                                AutoGenerateColumns="False" BorderStyle="Dotted" CssClass="grvResultadoConsultaCss" Font-Size="12px" ShowHeaderWhenEmpty="True"
                                 Width="90%" ShowHeader="False" BorderColor="White" DataKeyNames="Folio" PageSize="6"
                                 OnRowDeleting="grvAgregados_RowDeleting" OnPageIndexChanging="grvAgregados_PageIndexChanging">
                                 <Columns>
@@ -1770,68 +1781,72 @@
                     </tr>
                     <tr>
                         <td style="padding: 5px 5px 5px 5px">
-                            <asp:GridView ID="grvVistaRapidaInterno" runat="server" AutoGenerateColumns="False"
-                                BorderStyle="Dotted" Font-Size="12px" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
-                                Width="100%" GridLines="Horizontal">
-                                <EmptyDataTemplate>
-                                    <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="Sin detalle del folio de la conciliacion."></asp:Label>
-                                </EmptyDataTemplate>
-                                <Columns>
-                                    <asp:TemplateField HeaderText="Documento" SortExpression="referencia">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblReferencia" runat="server" Text="<%# Bind('Referencia') %>"></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="100px" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="FOperacion" SortExpression="fOperacion">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblFOperracion" runat="server" Text="<%# Bind('FOperacion', '{0:d}') %>"></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="FMovimiento" SortExpression="fMovimiento">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblFMovimiento" runat="server" Text="<%# Bind('FMovimiento','{0:d}') %>"></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="50px" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Descripcion" SortExpression="descripcion">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblDescripcion" runat="server" Text="<%# Bind('Descripcion') %>"></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="150px" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Deposito" SortExpression="deposito">
-                                        <ItemTemplate>
-                                            <b>
-                                                <asp:Label ID="lblDeposito" runat="server" Font-Size="10px" Width="100px" Text="<%# Bind('Deposito','{0:c2}') %>"></asp:Label></b>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
-                                            CssClass="fg-color-blanco bg-color-grisClaro" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Retiro" SortExpression="retiro">
-                                        <ItemTemplate>
-                                            <b>
-                                                <asp:Label ID="lblRetiro" runat="server" Font-Size="10px" Width="100px" Text="<%# Bind('Retiro','{0:c2}') %>"></asp:Label></b>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
-                                            CssClass="fg-color-blanco bg-color-grisClaro" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Concepto" SortExpression="concepto">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblConcepto" runat="server" Text="<%# Bind('Concepto') %>"></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" Wrap="True" Width="500px" />
-                                    </asp:TemplateField>
-                                </Columns>
-                            </asp:GridView>
+                            <div style="width:1000px; height:340px; overflow:auto;">
+                                <asp:GridView ID="grvVistaRapidaInterno" runat="server" 
+                                    AllowPaging='<%# ActivePaging %>' PageSize="5" 
+                                    AutoGenerateColumns="False" BorderStyle="Dotted" Font-Size="12px" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
+                                    Width="100%" GridLines="Horizontal"
+                                    OnPageIndexChanging="grvVistaRapidaInterno_PageIndexChanging">
+                                    <EmptyDataTemplate>
+                                        <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="Sin detalle del folio de la conciliacion."></asp:Label>
+                                    </EmptyDataTemplate>
+                                    <Columns>
+                                        <asp:TemplateField HeaderText="Documento" SortExpression="referencia">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblReferencia" runat="server" Text="<%# Bind('Referencia') %>"></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="100px" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="FOperacion" SortExpression="fOperacion">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblFOperracion" runat="server" Text="<%# Bind('FOperacion', '{0:d}') %>"></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="FMovimiento" SortExpression="fMovimiento">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblFMovimiento" runat="server" Text="<%# Bind('FMovimiento','{0:d}') %>"></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="50px" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Descripcion" SortExpression="descripcion">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblDescripcion" runat="server" Text="<%# Bind('Descripcion') %>"></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="150px" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Deposito" SortExpression="deposito">
+                                            <ItemTemplate>
+                                                <b>
+                                                    <asp:Label ID="lblDeposito" runat="server" Font-Size="10px" Width="100px" Text="<%# Bind('Deposito','{0:c2}') %>"></asp:Label></b>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
+                                                CssClass="fg-color-blanco bg-color-grisClaro" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Retiro" SortExpression="retiro">
+                                            <ItemTemplate>
+                                                <b>
+                                                    <asp:Label ID="lblRetiro" runat="server" Font-Size="10px" Width="100px" Text="<%# Bind('Retiro','{0:c2}') %>"></asp:Label></b>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
+                                                CssClass="fg-color-blanco bg-color-grisClaro" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Concepto" SortExpression="concepto">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblConcepto" runat="server" Text="<%# Bind('Concepto') %>"></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" Wrap="True" Width="500px" />
+                                        </asp:TemplateField>
+                                    </Columns>
+                                </asp:GridView>
+                            </div>
                         </td>
                     </tr>
                 </table>

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/Manual.aspx.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/Manual.aspx.cs
@@ -63,6 +63,26 @@ public partial class Conciliacion_FormasConciliar_Manual : System.Web.UI.Page
 
     private SeguridadCB.Seguridad seguridad = new SeguridadCB.Seguridad();
 
+    private bool activepaging = true;
+    public bool ActivePaging
+    {
+        get { return activaPaginacion(); }
+    }
+
+    public bool activaPaginacion()
+    {
+        SeguridadCB.Public.Parametros parametros;
+        parametros = (SeguridadCB.Public.Parametros)HttpContext.Current.Session["Parametros"];
+        AppSettingsReader settings = new AppSettingsReader();
+        bool activar;
+        usuario = (SeguridadCB.Public.Usuario)HttpContext.Current.Session["Usuario"];
+        activar = parametros.ValorParametro(Convert.ToSByte(settings.GetValue("Modulo", typeof(sbyte))), "ESTADOPAGINADORES") == "1";
+        //if (usuario.Area == 8) //el usuario es de metropoli
+        //    activar = parametros.ValorParametro(Convert.ToSByte(settings.GetValue("Modulo", typeof(sbyte))), "METROPOLIPAGINADORES") == "1";
+
+        return activar;
+    }
+
     protected override void OnPreInit(EventArgs e)
     {
         if (HttpContext.Current.Session["Operaciones"] == null)
@@ -90,6 +110,7 @@ public partial class Conciliacion_FormasConciliar_Manual : System.Web.UI.Page
                     HttpContext.Current.Response.Cache.SetAllowResponseInBrowserHistory(false);
                 }
             }
+            LlenaGridViewDestinoDetalleInterno();
             if (!Page.IsPostBack)
             {
                 //Leer variables de URL
@@ -2730,4 +2751,20 @@ public partial class Conciliacion_FormasConciliar_Manual : System.Web.UI.Page
 
     }
     //------------------------------FIN MODULO "AGREGAR NUEVO INTERNO" -----------------------------------
+
+    protected void grvDetalleArchivoInterno_PageIndexChanging(object sender, GridViewPageEventArgs e)
+    {
+        grvDetalleArchivoInterno.DataSource = tblDetalleTransaccionConciliada;
+        grvDetalleArchivoInterno.PageIndex = e.NewPageIndex;
+        grvDetalleArchivoInterno.DataBind();
+        mpeLanzarDetalle.Show();
+    }
+
+    protected void grvVistaRapidaInterno_PageIndexChanging(object sender, GridViewPageEventArgs e)
+    {
+        DataTable tablaDestinoDetalleInterno = (DataTable)HttpContext.Current.Session["DETALLEINTERNO"];
+        this.grvVistaRapidaInterno.DataSource = tablaDestinoDetalleInterno;
+        this.grvVistaRapidaInterno.PageIndex = e.NewPageIndex;
+        this.grvVistaRapidaInterno.DataBind();
+    }
 }

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx
@@ -1314,15 +1314,12 @@
 
                         <div id="divExternos" style="width:600px; height:350px; overflow:auto;" onscroll="rdbSecuencia_scrollpos();" >
                             <asp:GridView ID="grvExternos" runat="server" 
-                            AllowPaging='<%# ActivePaging %>' AutoGenerateColumns="False" ViewStateMode="Enabled"
-                            OnRowDataBound ="grvExternos_RowDataBound" ShowHeaderWhenEmpty="True" Width="100%"
-                            PageSize="10" AllowSorting="True" CssClass="grvResultadoConsultaCss"
-                            DataKeyNames="Corporativo,Sucursal,Año,Secuencia,Folio,StatusConciliacion,Referencia,Deposito"
-                            OnSorting="grvExternos_Sorting" OnPageIndexChanging="grvExternos_PageIndexChanging">
-                            <%--<EmptyDataTemplate>
-                                    <asp:Label ID="lblvacio" runat="server" Font-Bold="True" Font-Overline="False" ForeColor="#CC3300"
-                                        Text="No se encontraron referencias externas."></asp:Label>
-                                </EmptyDataTemplate>--%>
+                                AllowPaging='<%# ActivePaging %>' PageSize="10" 
+                                AutoGenerateColumns="False" ViewStateMode="Enabled"
+                                OnRowDataBound ="grvExternos_RowDataBound" ShowHeaderWhenEmpty="True" Width="100%"
+                                AllowSorting="True" CssClass="grvResultadoConsultaCss"
+                                DataKeyNames="Corporativo,Sucursal,Año,Secuencia,Folio,StatusConciliacion,Referencia,Deposito"
+                                OnSorting="grvExternos_Sorting" OnPageIndexChanging="grvExternos_PageIndexChanging">
                             <HeaderStyle HorizontalAlign="Center" />
                             <RowStyle CssClass="bg-color-blanco fg-color-negro" />
                             <Columns>
@@ -2118,17 +2115,13 @@
                                 <PagerStyle CssClass="grvPaginacionScroll" />
                             </asp:GridView>
                             <%-- <br />--%>
-
                             <div id="seccionGridPedidos">
                                 <asp:GridView ID="grvPedidos" runat="server" 
                                 AllowPaging='<%# ActivePaging %>' PageSize="3" AutoGenerateColumns="False" ShowHeader="True"
                                 CssClass="grvResultadoConsultaCss" AllowSorting="True" ShowFooter="False" Width="100%"
                                 ShowHeaderWhenEmpty="True" OnSorting="grvPedidos_Sorting" OnRowDataBound="grvPedidos_RowDataBound"
                                 OnRowCommand="grvPedidos_RowCommand" OnPageIndexChanging="grvPedidos_PageIndexChanging"
-                                DataKeyNames="Celula,Pedido,AñoPed,Cliente" > <%--PageSize="5" EnableViewState="True"--%>
-                                <%-- <EmptyDataTemplate>
-                                    <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="No se encontraron información sobre pedidos."></asp:Label>
-                                </EmptyDataTemplate>--%>
+                                DataKeyNames="Celula,Pedido,AñoPed,Cliente" > 
                                 <HeaderStyle HorizontalAlign="Center" />
                                 <Columns>
                                     <asp:TemplateField>
@@ -2300,7 +2293,7 @@
                     <tr>
                         <td style="padding: 5px 5px 5px 5px; width: 100%">
                             <div style="width:100%; height:auto; max-height:480px; overflow: auto;">
-                                <asp:GridView ID="grvDetalleArchivoInterno" runat="server" 
+                                <asp:GridView ID="grvDetalleArchivoInterno" PageSize="5" runat="server" 
                                     AllowPaging='<%# ActivePaging %>' AutoGenerateColumns="False"
                                     ShowHeader="True" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
                                     ShowFooter="False" DataKeyNames="SecuenciaInterno, FolioInterno">
@@ -2371,7 +2364,7 @@
                                     </Columns>
                                 </asp:GridView>
                                 <asp:GridView ID="grvDetallePedidoInterno" runat="server" 
-                                    AllowPaging='<%# ActivePaging %>' AutoGenerateColumns="False"
+                                    AllowPaging='<%# ActivePaging %>' PageSize="5" AutoGenerateColumns="False"
                                     ShowHeader="True" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
                                     DataKeyNames="Celula,Pedido,AñoPed">
                                     <HeaderStyle HorizontalAlign="Center" />

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx
@@ -81,11 +81,14 @@
                 grv = document.getElementById('ctl00_contenidoPrincipal_grvPedidos');
                 chkVal = document.getElementById('ctl00_contenidoPrincipal_chkSeleccionarInternosTodos').checked;
                 for (indice = 1; indice < grv.rows.length; indice++) {
-                    grv.rows[indice].cells[1].children[0].checked = chkVal;
-                    res = btnAgregarPedidoConciliacion(grv, indice);
-                    if (res == false) {
-                        document.getElementById('ctl00_contenidoPrincipal_grvPedidos').rows[indice].cells[1].children[0].checked = false;
-                        break;
+                    if (grv.rows[i].cells[1] != undefined) {
+                        grv.rows[indice].cells[1].children[0].checked = chkVal;
+                        res = btnAgregarPedidoConciliacion(grv, indice);
+                        if (res == false) {
+                            document.getElementById('ctl00_contenidoPrincipal_grvPedidos').rows[indice].cells[1].children[0].checked = false;
+                            break;
+                        }
+
                     }
                 }
             }
@@ -124,7 +127,7 @@
             var dChequeados = 0.0;
             grv = document.getElementById('ctl00_contenidoPrincipal_grvPedidos');
             for (i = 1; i < grv.rows.length; i++) {
-                if (grv.rows[i].cells[1].children[0].checked == true)
+                if (grv.rows[i].cells[1] != undefined && grv.rows[i].cells[1].children[0].checked == true)
                     dChequeados = parseFloat(dChequeados) + parseFloat(grv.rows[i].cells[3].innerText.replace(',', '').replace('$','').trim());
             }
 
@@ -997,8 +1000,10 @@
                     <td>
                         <asp:UpdatePanel runat="server" ID="upGrvConciliadas" UpdateMode="Always">
                             <ContentTemplate>
-                                <asp:GridView ID="grvConciliadas" runat="server" AutoGenerateColumns="False" AllowPaging="True"
-                                    PageSize="5" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
+                                <div style="width:1200px; height:230px; overflow:auto;">
+                                    <asp:GridView ID="grvConciliadas" runat="server" AutoGenerateColumns="False" 
+                                    AllowPaging='<%# ActivePaging %>' PageSize="5"
+                                    Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
                                     OnPageIndexChanging="grvConciliadas_PageIndexChanging" OnRowDataBound="grvConciliadas_RowDataBound"
                                     DataKeyNames="CorporativoConciliacion,SucursalConciliacion,AñoConciliacion,MesConciliacion,FolioConciliacion,FolioExterno,SecuenciaExterno,Pedido"
                                     OnRowCommand="grvConciliadas_RowCommand" OnSelectedIndexChanging="grvConciliadas_SelectedIndexChanging"
@@ -1040,7 +1045,7 @@
                                             <ItemStyle HorizontalAlign="Center"></ItemStyle>
                                             <HeaderStyle HorizontalAlign="Center"></HeaderStyle>
                                         </asp:TemplateField>
-                                        <asp:TemplateField HeaderText="Mont. Conciliado" SortExpression="MontoConciliado">
+                                        <asp:TemplateField HeaderText="$Conciliado" SortExpression="MontoConciliado">
                                             <ItemTemplate>
                                                 <b>
                                                     <asp:Label ID="lblDeposito" runat="server" Text='<%# resaltarBusqueda(Eval("MontoConciliado","{0:c2}").ToString()) %>'></asp:Label></b>
@@ -1127,8 +1132,8 @@
                                                 <asp:Button runat="server" ID="imgDetalleConciliado" CssClass="Detalle centradoMedio boton"
                                                     ToolTip="VER DETALLE" Width="20px" Height="20px" CommandName="Select" />
                                             </ItemTemplate>
-                                            <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" Width="80px"></ItemStyle>
-                                            <HeaderStyle HorizontalAlign="Center" Width="80px"></HeaderStyle>
+                                            <ItemStyle HorizontalAlign="Center" VerticalAlign="Top" Width="90px"></ItemStyle>
+                                            <HeaderStyle HorizontalAlign="Center" Width="90px"></HeaderStyle>
                                         </asp:TemplateField>
                                         
                                     </Columns>
@@ -1152,6 +1157,7 @@
                                     </PagerTemplate>
                                     <PagerStyle CssClass="estiloPaginacion bg-color-grisOscuro fg-color-blanco" />
                                 </asp:GridView>
+                                </div>
                             </ContentTemplate>
                         </asp:UpdatePanel>
                     </td>
@@ -1307,9 +1313,10 @@
                         </div>
 
                         <div id="divExternos" style="width:600px; height:350px; overflow:auto;" onscroll="rdbSecuencia_scrollpos();" >
-                            <asp:GridView ID="grvExternos" runat="server" AutoGenerateColumns="False" ViewStateMode="Enabled"
+                            <asp:GridView ID="grvExternos" runat="server" 
+                            AllowPaging='<%# ActivePaging %>' AutoGenerateColumns="False" ViewStateMode="Enabled"
                             OnRowDataBound ="grvExternos_RowDataBound" ShowHeaderWhenEmpty="True" Width="100%"
-                            AllowPaging="True" PageSize="100" AllowSorting="True" CssClass="grvResultadoConsultaCss"
+                            PageSize="10" AllowSorting="True" CssClass="grvResultadoConsultaCss"
                             DataKeyNames="Corporativo,Sucursal,Año,Secuencia,Folio,StatusConciliacion,Referencia,Deposito"
                             OnSorting="grvExternos_Sorting" OnPageIndexChanging="grvExternos_PageIndexChanging">
                             <%--<EmptyDataTemplate>
@@ -1782,13 +1789,14 @@
                             </tr>
                         </table>
                         <div id="dvAgregados" style="display: none">
-                            <%--<asp:UpdatePanel ID="UpdatePanel1" runat="server" UpdateMode="Conditional">
-                                <ContentTemplate>--%>							 
-                            <asp:GridView ID="grvAgregadosPedidos" runat="server" AutoGenerateColumns="False"
-                                AllowPaging="False" ShowHeader="False" Width="100%" CssClass="grvResultadoConsultaCss"
-                                PageSize="10" OnRowDataBound="grvAgregadosPedidos_RowDataBound" ShowHeaderWhenEmpty="False"
-                                ShowFooter="False" DataKeyNames="Celula,Pedido,AñoPed,Cliente" 
-                                OnRowCreated="grvAgregadosPedidos_RowCreated" ViewStateMode="Enabled">
+                            <div style="width:600px; height:100px; overflow:auto;">
+                                <asp:GridView ID="grvAgregadosPedidos" runat="server" AutoGenerateColumns="False"
+                                    AllowPaging='<%# ActivePaging %>' PageSize="5" 
+                                    ShowHeader="False" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="False"
+                                    ShowFooter="False" DataKeyNames="Celula,Pedido,AñoPed,Cliente" ViewStateMode="Enabled"
+                                    OnRowDataBound="grvAgregadosPedidos_RowDataBound" 
+                                    OnRowCreated="grvAgregadosPedidos_RowCreated" 
+                                    OnPageIndexChanging="grvAgregadosPedidos_PageIndexChanging">
                                 <HeaderStyle HorizontalAlign="Center" />
                                 <Columns>
                                     <asp:TemplateField>
@@ -1867,13 +1875,11 @@
                                     </asp:TemplateField>
                                 </Columns>
                             </asp:GridView>
-						    <%--</ContentTemplate>
-                        </asp:UpdatePanel>--%>		
-						
-                            <asp:GridView ID="grvAgregadosInternos" runat="server" AutoGenerateColumns="False"
-                                AllowPaging="False" ShowHeader="True" Width="100%" CssClass="grvResultadoConsultaCss"
-                                PageSize="10" ShowHeaderWhenEmpty="False" ShowFooter="False" DataKeyNames="Folio,Secuencia,Año,Sucursal"
-                                OnRowCreated="grvAgregadosInternos_RowCreated">
+    						    <asp:GridView ID="grvAgregadosInternos" runat="server" AutoGenerateColumns="False"
+                                AllowPaging='<%# ActivePaging %>' PageSize="5" ShowHeader="True" Width="100%" CssClass="grvResultadoConsultaCss"
+                                ShowHeaderWhenEmpty="False" ShowFooter="False" DataKeyNames="Folio,Secuencia,Año,Sucursal"
+                                OnRowCreated="grvAgregadosInternos_RowCreated"
+                                OnPageIndexChanging="grvAgregadosInternos_PageIndexChanging" >
                                 <HeaderStyle HorizontalAlign="Center" />
                                 <Columns>
                                     <asp:TemplateField>
@@ -1963,13 +1969,13 @@
                                 </PagerTemplate>
                                 <PagerStyle CssClass="estiloPaginacion bg-color-grisClaro fg-color-blanco" />
                             </asp:GridView>
+                            </div>
                         </div>
                         <div style="width:588px; height:250px; overflow:auto;">
                             <asp:GridView ID="grvInternos" runat="server" AutoGenerateColumns="False" ShowHeader="True"
-                                AllowPaging="True" CssClass="grvResultadoConsultaCss" AllowSorting="True" OnRowDataBound="grvInternos_RowDataBound"
+                                AllowPaging='<%# ActivePaging %>' PageSize="3" CssClass="grvResultadoConsultaCss" AllowSorting="True" OnRowDataBound="grvInternos_RowDataBound"
                                 ShowHeaderWhenEmpty="False" ShowFooter="False" Width="100%" DataKeyNames="Secuencia, Folio, Sucursal"
-                                OnSorting="grvInternos_Sorting" OnPageIndexChanging="grvInternos_PageIndexChanging"
-                                PageSize="100">
+                                OnSorting="grvInternos_Sorting" OnPageIndexChanging="grvInternos_PageIndexChanging">
                                 <HeaderStyle HorizontalAlign="Center" />
                                 <Columns>
                                     <asp:TemplateField>
@@ -2111,13 +2117,14 @@
                                 </Columns>
                                 <PagerStyle CssClass="grvPaginacionScroll" />
                             </asp:GridView>
-                            <br />
+                            <%-- <br />--%>
 
                             <div id="seccionGridPedidos">
-                                <asp:GridView ID="grvPedidos" runat="server" AutoGenerateColumns="False" ShowHeader="True"
+                                <asp:GridView ID="grvPedidos" runat="server" 
+                                AllowPaging='<%# ActivePaging %>' PageSize="3" AutoGenerateColumns="False" ShowHeader="True"
                                 CssClass="grvResultadoConsultaCss" AllowSorting="True" ShowFooter="False" Width="100%"
                                 ShowHeaderWhenEmpty="True" OnSorting="grvPedidos_Sorting" OnRowDataBound="grvPedidos_RowDataBound"
-                                OnRowCommand="grvPedidos_RowCommand" AllowPaging="False" OnPageIndexChanging="grvPedidos_PageIndexChanging"
+                                OnRowCommand="grvPedidos_RowCommand" OnPageIndexChanging="grvPedidos_PageIndexChanging"
                                 DataKeyNames="Celula,Pedido,AñoPed,Cliente" > <%--PageSize="5" EnableViewState="True"--%>
                                 <%-- <EmptyDataTemplate>
                                     <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="No se encontraron información sobre pedidos."></asp:Label>
@@ -2293,7 +2300,8 @@
                     <tr>
                         <td style="padding: 5px 5px 5px 5px; width: 100%">
                             <div style="width:100%; height:auto; max-height:480px; overflow: auto;">
-                                <asp:GridView ID="grvDetalleArchivoInterno" runat="server" AutoGenerateColumns="False"
+                                <asp:GridView ID="grvDetalleArchivoInterno" runat="server" 
+                                    AllowPaging='<%# ActivePaging %>' AutoGenerateColumns="False"
                                     ShowHeader="True" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
                                     ShowFooter="False" DataKeyNames="SecuenciaInterno, FolioInterno">
                                     <EmptyDataTemplate>
@@ -2362,7 +2370,8 @@
                                         </asp:TemplateField>
                                     </Columns>
                                 </asp:GridView>
-                                <asp:GridView ID="grvDetallePedidoInterno" runat="server" AutoGenerateColumns="False"
+                                <asp:GridView ID="grvDetallePedidoInterno" runat="server" 
+                                    AllowPaging='<%# ActivePaging %>' AutoGenerateColumns="False"
                                     ShowHeader="True" Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
                                     DataKeyNames="Celula,Pedido,AñoPed">
                                     <HeaderStyle HorizontalAlign="Center" />
@@ -2675,7 +2684,8 @@
                             <div class="etiqueta">
                                 Folios Agregados
                             </div>
-                            <asp:GridView ID="grvAgregados" runat="server" AllowPaging="True" AutoGenerateColumns="False"
+                            <asp:GridView ID="grvAgregados" runat="server" 
+                                AllowPaging='<%# ActivePaging %>' AutoGenerateColumns="False"
                                 BorderStyle="Dotted" CssClass="grvResultadoConsultaCss" Font-Size="12px" ShowHeaderWhenEmpty="True"
                                 Width="90%" ShowHeader="True" BorderColor="White" DataKeyNames="Folio" PageSize="6"
                                 OnRowDeleting="grvAgregados_RowDeleting" OnPageIndexChanging="grvAgregados_PageIndexChanging">
@@ -2687,7 +2697,7 @@
                                         </ItemTemplate>
                                         <ItemStyle HorizontalAlign="Center" Wrap="True" Width="30px" />
                                     </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Folias Agregados" SortExpression="fAgregados">
+                                    <asp:TemplateField HeaderText="Folios Agregados" SortExpression="fAgregados">
                                         <ItemTemplate>
                                             <asp:Label ID="lblFoliosAgregados" runat="server" Text = '<%# Eval("Folio")%>'></asp:Label>
                                         </ItemTemplate>
@@ -2745,68 +2755,72 @@
                     </tr>
                     <tr>
                         <td style="padding: 5px 5px 5px 5px">
-                            <asp:GridView ID="grvVistaRapidaInterno" runat="server" AutoGenerateColumns="False"
-                                BorderStyle="Dotted" Font-Size="12px" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
-                                Width="100%" GridLines="Horizontal">
-                                <EmptyDataTemplate>
-                                    <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="Sin detalle del folio de la conciliacion."></asp:Label>
-                                </EmptyDataTemplate>
-                                <Columns>
-                                    <asp:TemplateField HeaderText="Documento" SortExpression="referencia">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblReferencia" runat="server" Text='<%# Eval("Referencia") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="100px" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="FOperacion" SortExpression="fOperacion">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblFOperracion" runat="server" Text='<%# Eval("FOperacion", "{0:d}") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="FMovimiento" SortExpression="fMovimiento">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblFMovimiento" runat="server" Text='<%# Eval("FMovimiento","{0:d}") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="50px" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Descripcion" SortExpression="descripcion">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblDescripcion" runat="server" Text='<%# Eval("Descripcion") %>'></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="150px" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Deposito" SortExpression="deposito">
-                                        <ItemTemplate>
-                                            <b>
-                                                <asp:Label ID="lblDeposito" runat="server" Font-Size="10px" Width="100px" Text='<%# Eval("Deposito") %>'></asp:Label></b>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
-                                            CssClass="fg-color-blanco bg-color-grisClaro" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Retiro" SortExpression="retiro">
-                                        <ItemTemplate>
-                                            <b>
-                                                <asp:Label ID="lblRetiro" runat="server" Font-Size="10px" Width="100px" Text='<%# Bind("Retiro","{0:c2}") %>'></asp:Label></b>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
-                                            CssClass="fg-color-blanco bg-color-grisClaro" />
-                                    </asp:TemplateField>
-                                    <asp:TemplateField HeaderText="Concepto" SortExpression="concepto">
-                                        <ItemTemplate>
-                                            <asp:Label ID="lblConcepto" runat="server" Text=<%# Bind("Concepto") %>></asp:Label>
-                                        </ItemTemplate>
-                                        <HeaderStyle HorizontalAlign="Center" />
-                                        <ItemStyle HorizontalAlign="Justify" Wrap="True" Width="500px" />
-                                    </asp:TemplateField>
-                                </Columns>
-                            </asp:GridView>
+                            <div style="width:1000px; height:340px; overflow:auto;">
+                                <asp:GridView ID="grvVistaRapidaInterno" runat="server"
+                                    AllowPaging='<%# ActivePaging %>' PageSize="5" AutoGenerateColumns="False"
+                                    BorderStyle="Dotted" Font-Size="12px" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
+                                    Width="100%" GridLines="Horizontal"
+                                    OnPageIndexChanging="grvVistaRapidaInterno_PageIndexChanging" >
+                                    <EmptyDataTemplate>
+                                        <asp:Label ID="lblvacio" runat="server" CssClass="etiqueta fg-color-rojo" Text="Sin detalle del folio de la conciliacion."></asp:Label>
+                                    </EmptyDataTemplate>
+                                    <Columns>
+                                        <asp:TemplateField HeaderText="Documento" SortExpression="referencia">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblReferencia" runat="server" Text='<%# Eval("Referencia") %>'></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="100px" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="FOperacion" SortExpression="fOperacion">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblFOperracion" runat="server" Text='<%# Eval("FOperacion", "{0:d}") %>'></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="FMovimiento" SortExpression="fMovimiento">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblFMovimiento" runat="server" Text='<%# Eval("FMovimiento","{0:d}") %>'></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="50px" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Descripcion" SortExpression="descripcion">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblDescripcion" runat="server" Text='<%# Eval("Descripcion") %>'></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" VerticalAlign="Middle" Wrap="True" Width="150px" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Deposito" SortExpression="deposito">
+                                            <ItemTemplate>
+                                                <b>
+                                                    <asp:Label ID="lblDeposito" runat="server" Font-Size="10px" Width="100px" Text='<%# Eval("Deposito") %>'></asp:Label></b>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
+                                                CssClass="fg-color-blanco bg-color-grisClaro" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Retiro" SortExpression="retiro">
+                                            <ItemTemplate>
+                                                <b>
+                                                    <asp:Label ID="lblRetiro" runat="server" Font-Size="10px" Width="100px" Text='<%# Bind("Retiro","{0:c2}") %>'></asp:Label></b>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Right" VerticalAlign="Middle" Wrap="True" Width="100px"
+                                                CssClass="fg-color-blanco bg-color-grisClaro" />
+                                        </asp:TemplateField>
+                                        <asp:TemplateField HeaderText="Concepto" SortExpression="concepto">
+                                            <ItemTemplate>
+                                                <asp:Label ID="lblConcepto" runat="server" Text=<%# Bind("Concepto") %>></asp:Label>
+                                            </ItemTemplate>
+                                            <HeaderStyle HorizontalAlign="Center" />
+                                            <ItemStyle HorizontalAlign="Justify" Wrap="True" Width="500px" />
+                                        </asp:TemplateField>
+                                    </Columns>
+                                </asp:GridView>
+                            </div>
                         </td>
                     </tr>
                 </table>

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx.cs
@@ -517,8 +517,8 @@ public partial class Conciliacion_FormasConciliar_UnoAVarios : System.Web.UI.Pag
         bool activar;
         usuario = (SeguridadCB.Public.Usuario)HttpContext.Current.Session["Usuario"];
         activar = parametros.ValorParametro(Convert.ToSByte(settings.GetValue("Modulo", typeof(sbyte))), "ESTADOPAGINADORES") == "1";
-        if (usuario.Area == 8) //el usuario es de metropoli
-            activar = parametros.ValorParametro(Convert.ToSByte(settings.GetValue("Modulo", typeof(sbyte))), "METROPOLIPAGINADORES") == "1";
+        //if (usuario.Area == 8) //el usuario es de metropoli
+        //W    activar = parametros.ValorParametro(Convert.ToSByte(settings.GetValue("Modulo", typeof(sbyte))), "METROPOLIPAGINADORES") == "1";
 
         return activar;
     }


### PR DESCRIPTION
Los usuarios del sistema de conciliación bancaria requieren reducir los tiempos de identificación de registros en los grids que el sistema muestra, por lo anterior se requiere de eliminar sus paginadores

1. Utilizar el parámetro de base de datos llamado ESTADOPAGINADORES con los valores posibles 1 o 0 para el módulo de conciliación bancaria
2. Utilizar el parámetro de base de datos llamado METROPOLIPAGINADORES con los valores posibles 1 o 0 para el módulo de conciliación bancaria
3. En la página CantidadConcuerda.aspx crear un panel HTML con altura y ancho fijos en el que el grid grvCantidadConcuerdanArchivos, grvCantidadConcuerdanPedidos, grvDetalleArchivoInterno, grvDetallePedidoInterno, grvAgregados y grvVistaRapidaInterno    puede tener las dimensiones con las que actualmente cuenta
4. Modificar el método de carga de la página para asignar un valor de verdad a la propiedad AllowPaging A LOS GRIDS MENCIONADOS EN EL PUNTO TRES de acuerdo a la siguiente tabla de verdad