### PR TITLE
Se hacen correcciones derivados de los cambios de paralelismo:

### DIFF
--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/Conciliacion.RunTime/ReglasDeNegocio/ExportadorInformeEstadoCuenta.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/Conciliacion.RunTime/ReglasDeNegocio/ExportadorInformeEstadoCuenta.cs
@@ -100,15 +100,9 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
 
         private ExcelPackage crearEncabezado(ExcelPackage excelPackage, string nombrehoja)
         {
-            string banco, cuenta, empresa, saldofinal, depositos, retiro;
             DateTime fecha;
             CultureInfo cultureInfo = CultureInfo.GetCultureInfo("es-MX");
-
-            banco = "BANAMEX ";
-            cuenta = "CTA ";// + _ReporteEstadoCuentaConciliado[0].CuentaBancoFinanciero + " ";
-            empresa = "Corporativo";//_ReporteEstadoCuentaConciliado[0].Corporativo;
             fecha = DateTime.Now;//_ReporteEstadoCuentaConciliado[0].Fecha;
-
             //// banco = _DetalleReporteEstadoCuenta[0].
             //  banco = "BANAMEX ";
             // cuenta = "CTA " + ListaEncabezado[0].CuentaBancoFinanciero + " ";
@@ -118,18 +112,12 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
             // saldofinal = ListaEncabezado[0].SaldoFinal;
             // depositos = ListaEncabezado[0].Depositos;
 
-            //if (excelPackage.Workbook.Worksheets.Count > 0)
-            //{
-            //    nombrehoja = "hoja2";
-            //}
-
-            ExcelWorksheet wsSheet1 = excelPackage.Workbook.Worksheets.Add(nombrehoja);
-            
+            ExcelWorksheet wsSheet1 = excelPackage.Workbook.Worksheets.Add(nombrehoja.Trim());
 
             // Cuenta
             using (ExcelRange Rng = wsSheet1.Cells["B1:H1"])
             {
-                Rng.Value = banco.ToUpper() + cuenta.ToUpper() + " MOVIMIENTOS DEL MES DE: " + fecha.ToString("MMMM", cultureInfo).ToUpper(); ;
+                Rng.Value = _NombreHoja + " MOVIMIENTOS DEL MES DE: " + fecha.ToString("MMMM", cultureInfo).ToUpper(); ;
                 Rng.Merge = true;
             }
 
@@ -137,7 +125,7 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
             using (ExcelRange Rng = wsSheet1.Cells["B2:H2"])
             {
                 Rng.Merge = true;
-                Rng.Value = empresa.ToUpper();
+                Rng.Value = "";// empresa.ToUpper();
             }
 
             // Mes
@@ -241,7 +229,7 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
         {
             int i = aPartirDeLaFila;
 
-            ExcelWorksheet wsSheet1 = excelPackage.Workbook.Worksheets[nombreHoja];
+            ExcelWorksheet wsSheet1 = excelPackage.Workbook.Worksheets[nombreHoja.Trim()];
 
             foreach (DetalleReporteEstadoCuenta detalle in _ReporteEstadoCuenta)
             {

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/Conciliacion.RunTime/ReglasDeNegocio/ExportadorInformeEstadoCuentaDia.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/Conciliacion.RunTime/ReglasDeNegocio/ExportadorInformeEstadoCuentaDia.cs
@@ -63,7 +63,7 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
                     ExcelPackage excelPackage = inicializar();
                     for (int i = 0; i <= _ReporteEstadoCuentaDia.Count-1; i++)
                     {
-                            crearEncabezado(excelPackage, _ReporteEstadoCuentaDia[i][0].CuentaBancoFinanciero.ToString()) ;
+                            crearEncabezado(excelPackage, _ReporteEstadoCuentaDia[i][0].CuentaBancoFinanciero.ToString(), "","");
                             exportarDatos(excelPackage, _ReporteEstadoCuentaDia[i][0].CuentaBancoFinanciero.ToString(), 5, _ReporteEstadoCuentaDia[i]);
                     }
                     excelPackage.Save();
@@ -100,11 +100,12 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
             return excel;
         }
 
-        private ExcelPackage crearEncabezado(ExcelPackage excelPackage, string nombrehoja)
+        private ExcelPackage crearEncabezado(ExcelPackage excelPackage, string nombrehoja, string banco, string cuenta)
         {
             //string banco, cuenta, empresa, saldofinal, depositos, retiro;
             
             CultureInfo cultureInfo = CultureInfo.GetCultureInfo("es-MX");
+            
 
             //banco = "BANAMEX ";
             //cuenta = "CTA ";// + _ReporteEstadoCuentaConciliado[0].CuentaBancoFinanciero + " ";
@@ -124,13 +125,14 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
             //{
             //    nombrehoja = "hoja2";
             //}
-            
+
             ExcelWorksheet wsSheet1 = excelPackage.Workbook.Worksheets.Add(nombrehoja);
             
             // Cuenta
             using (ExcelRange Rng = wsSheet1.Cells["B1:G1"])
             {
-                Rng.Value = _Banco.ToUpper() + _Cuenta.ToUpper() + " MOVIMIENTOS DEL MES DE: " + _MesDelPeriodo;
+                //Rng.Value = _Banco.ToUpper() + _Cuenta.ToUpper() + " MOVIMIENTOS DEL MES DE: " + _MesDelPeriodo;
+                Rng.Value = nombrehoja + " MOVIMIENTOS DEL MES DE: " + _MesDelPeriodo;
                 Rng.Merge = true;
             }
 
@@ -258,8 +260,10 @@ namespace Conciliacion.RunTime.ReglasDeNegocio
 
                 i++;
             }
-
             i++;
+            wsSheet1.Cells[i, 8, i, 9].Merge = true;
+            wsSheet1.Cells[i, 10, i, 11].Merge = true;
+            wsSheet1.Cells[i, 12, i, 13].Merge = true;
             wsSheet1.Cells[i, 8].Value = sumaRetiros;
             wsSheet1.Cells[i, 10].Value = sumaDepositos;
             wsSheet1.Cells[i, 12].Value = saldoFila;

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/CantidadYReferenciaConcuerdan.aspx
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/CantidadYReferenciaConcuerdan.aspx
@@ -1,6 +1,9 @@
-﻿<%@ Page Title="" Language="C#" MasterPageFile="~/Principal.master" AutoEventWireup="true"
-    CodeFile="CantidadYReferenciaConcuerdan.aspx.cs" Inherits="Conciliacion_FormasConciliar_CantidadYReferenciaConcuerdan"
-    Debug="true" EnableEventValidation="true" Async="true" %>
+﻿<%@ Page Title="" Language="C#" MasterPageFile="~/Principal.master" 
+    AutoEventWireup="true"
+    CodeFile="CantidadYReferenciaConcuerdan.aspx.cs" 
+    Inherits="Conciliacion_FormasConciliar_CantidadYReferenciaConcuerdan"
+    EnableEventValidation="true" 
+    Async="true" %>
 
 <%@ Register Assembly="AjaxControlToolkit" Namespace="AjaxControlToolkit" TagPrefix="asp" %>
 
@@ -431,8 +434,8 @@
                 <asp:UpdatePanel runat="server" ID="upGrvConciliadas" UpdateMode="Always">
                     <ContentTemplate>
                         <div style="width:1200px; height:230px; overflow:auto;">
-                            <asp:GridView ID="grvConciliadas" runat="server" AutoGenerateColumns="False" 
-                            AllowPaging='<%# ActivePaging %>' PageSize="5" 
+                            <asp:GridView ID="grvConciliadas" runat="server" AutoGenerateColumns="False"  
+                            AllowPaging='<%# ActivePaging %>' PageSize="5"
                             Width="100%" CssClass="grvResultadoConsultaCss" ShowHeaderWhenEmpty="True"
                             OnPageIndexChanging="grvConciliadas_PageIndexChanging" OnRowDataBound="grvConciliadas_RowDataBound"
                             DataKeyNames="CorporativoConciliacion, SucursalConciliacion, AñoConciliacion, MesConciliacion, FolioConciliacion, FolioExt, Secuencia"

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/CantidadYReferenciaConcuerdan.aspx.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/CantidadYReferenciaConcuerdan.aspx.cs
@@ -142,10 +142,11 @@ public partial class Conciliacion_FormasConciliar_CantidadYReferenciaConcuerdan 
                     HttpContext.Current.Response.Cache.SetAllowResponseInBrowserHistory(false);
                 }
             }
+
             LlenaGridViewDestinoDetalleInterno();
+
             if (!Page.IsPostBack)
             {
-
                 corporativo = Convert.ToInt32(Request.QueryString["Corporativo"]);
                 sucursal = Convert.ToInt16(Request.QueryString["Sucursal"]);
                 año = Convert.ToInt32(Request.QueryString["Año"]);
@@ -245,11 +246,12 @@ public partial class Conciliacion_FormasConciliar_CantidadYReferenciaConcuerdan 
 
             //CARGAR LAS TRANSACCIONES CONCILIADAS POR EL CRITERIO DE AUTOCONCILIACIÓN
             if (ddlCriteriosConciliacion.SelectedValue == "2" || ddlCriteriosConciliacion.SelectedValue == "7")
-            { 
-                Consulta_TransaccionesConciliadas(corporativo, sucursal, año, mes, folio, Convert.ToInt32(ddlCriteriosConciliacion.SelectedValue));
-                GenerarTablaConciliados();
-                LlenaGridViewConciliadas();
-            }
+                if (corporativo != 0 && sucursal != 0 && año != 0 && mes != 0 && folio != 0)
+                { 
+                    Consulta_TransaccionesConciliadas(corporativo, sucursal, año, mes, folio, Convert.ToInt32(ddlCriteriosConciliacion.SelectedValue));
+                    GenerarTablaConciliados();
+                    LlenaGridViewConciliadas();
+                }
         }
         catch (SqlException ex)
         {
@@ -879,11 +881,14 @@ public partial class Conciliacion_FormasConciliar_CantidadYReferenciaConcuerdan 
             if (cliente == null)
             {
                 consultaClienteCRM(numCliente, (SeguridadCB.Public.Usuario)Session["Usuario"], byte.Parse(settings.GetValue("Modulo", typeof(string)).ToString()), App.CadenaConexion);
-                NombreCliente = lstClientes.FirstOrDefault(x => x.NumCliente == numCliente).Nombre;
-                cliente = App.Cliente.CrearObjeto();
-                cliente.NumCliente = numCliente;
-                cliente.Nombre = NombreCliente;
-                lstClientes.Add(cliente);
+                if (lstClientes.Count > 0)
+                { 
+                    NombreCliente = lstClientes.FirstOrDefault(x => x.NumCliente == numCliente).Nombre;
+                    cliente = App.Cliente.CrearObjeto();
+                    cliente.NumCliente = numCliente;
+                    cliente.Nombre = NombreCliente;
+                    lstClientes.Add(cliente);
+                }
             }
             else
             {
@@ -1413,24 +1418,32 @@ public partial class Conciliacion_FormasConciliar_CantidadYReferenciaConcuerdan 
     //Crea la paginacion para Concilidos
     protected void grvConciliadas_RowDataBound(object sender, GridViewRowEventArgs e)
     {
-        if (e.Row.RowType == DataControlRowType.DataRow)
+        try
         {
-
-        }
-
-        if (e.Row.RowType == DataControlRowType.Pager && (grvConciliadas.DataSource != null))
-        {
-            //TRAE EL TOTAL DE PAGINAS
-            Label _TotalPags = (Label)e.Row.FindControl("lblTotalNumPaginas");
-            _TotalPags.Text = grvConciliadas.PageCount.ToString();
-
-            //LLENA LA LISTA CON EL NUMERO DE PAGINAS
-            DropDownList list = (DropDownList)e.Row.FindControl("paginasDropDownListConciliadas");
-            for (int i = 1; i <= Convert.ToInt32(grvConciliadas.PageCount); i++)
+            if (e.Row.RowType == DataControlRowType.DataRow)
             {
-                list.Items.Add(i.ToString());
+
             }
-            list.SelectedValue = (grvConciliadas.PageIndex + 1).ToString();
+
+            if (e.Row.RowType == DataControlRowType.Pager && (grvConciliadas.DataSource != null))
+            {
+                //TRAE EL TOTAL DE PAGINAS
+                Label _TotalPags = (Label)e.Row.FindControl("lblTotalNumPaginas");
+                _TotalPags.Text = grvConciliadas.PageCount.ToString();
+
+                //LLENA LA LISTA CON EL NUMERO DE PAGINAS
+                DropDownList list = (DropDownList)e.Row.FindControl("paginasDropDownListConciliadas");
+                for (int i = 1; i <= Convert.ToInt32(grvConciliadas.PageCount); i++)
+                {
+                    list.Items.Add(i.ToString());
+                }
+                list.SelectedValue = (grvConciliadas.PageIndex + 1).ToString();
+            }
+        }
+        catch (Exception)
+        {
+
+            throw;
         }
     }
     //Asignar Valoresa Css de cada Row

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx
@@ -1,6 +1,10 @@
-﻿<%@ Page Title="" Language="C#" MasterPageFile="~/Principal.master" AutoEventWireup="true"
-    CodeFile="UnoAVarios.aspx.cs" Inherits="Conciliacion_FormasConciliar_UnoAVarios"
-    MaintainScrollPositionOnPostback="false" EnableEventValidation="false" Async="true" %>
+﻿<%@ Page Title="" Language="C#" MasterPageFile="~/Principal.master" 
+    AutoEventWireup="true"
+    CodeFile="UnoAVarios.aspx.cs" 
+    Inherits="Conciliacion_FormasConciliar_UnoAVarios"
+    MaintainScrollPositionOnPostback="false" 
+    EnableEventValidation="false" 
+    Async="true" %>
     
 <%@ Register Assembly="AjaxControlToolkit" Namespace="AjaxControlToolkit" TagPrefix="asp" %>
 <%@ Register Src="~//ControlesUsuario/CargaManualExcelCyC/wucCargaManualExcelCyC.ascx" TagPrefix="uc1" TagName="WebUserControl" %>

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Conciliacion/FormasConciliar/UnoAVarios.aspx.cs
@@ -7124,6 +7124,10 @@ public partial class Conciliacion_FormasConciliar_UnoAVarios : System.Web.UI.Pag
     protected void btnFiltraCliente_Click(object sender, ImageClickEventArgs e)
     {
         GridView grvPrima = null;
+        SeguridadCB.Public.Parametros parametros;
+        AppSettingsReader settings = new AppSettingsReader();
+        parametros = (SeguridadCB.Public.Parametros)HttpContext.Current.Session["Parametros"];
+        _URLGateway = parametros.ValorParametro(Convert.ToSByte(settings.GetValue("Modulo", typeof(sbyte))), "URLGateway").Trim();
         try
         {
             if (tipoConciliacion == 2)
@@ -7153,39 +7157,39 @@ public partial class Conciliacion_FormasConciliar_UnoAVarios : System.Web.UI.Pag
                         tableBuscaCliente = EliminarPedidosAgregados(tableBuscaCliente);
                     HttpContext.Current.Session["PedidosBuscadosPorUsuario"] = tableBuscaCliente;
                     ViewState["tipo"] = "2";
-                    HttpContext.Current.Session["PedidosBuscadosPorUsuario_AX"] = tableBuscaCliente_AX; // wucBuscaClientesFacturas.BuscaCliente();
-                    //grvPedidos.DataSource = (DataTable)HttpContext.Current.Session["PedidosBuscadosPorUsuario"];
-                    //grvPedidos.DataBind();
-                    //grvPedidos.DataBind();
-                    List<int> listaClientesDistintos = new List<int>();
-                    foreach (DataRow item in tableBuscaCliente.Rows)
+                    HttpContext.Current.Session["PedidosBuscadosPorUsuario_AX"] = tableBuscaCliente_AX; 
+                    if (_URLGateway != "")
                     {
-                        if (item["Cliente"].ToString() != string.Empty)
+                        List<int> listaClientesDistintos = new List<int>();
+                        foreach (DataRow item in tableBuscaCliente.Rows)
                         {
-                            if(!listaDireccinEntrega.Exists(x=>x.IDDireccionEntrega == int.Parse(item["Cliente"].ToString())))
+                            if (item["Cliente"].ToString() != string.Empty)
                             {
-                                if (!listaClientesDistintos.Exists(x => x == int.Parse(item["Cliente"].ToString())))
+                                if (!listaDireccinEntrega.Exists(x => x.IDDireccionEntrega == int.Parse(item["Cliente"].ToString())))
                                 {
-                                    listaClientesDistintos.Add(int.Parse(item["Cliente"].ToString()));
+                                    if (!listaClientesDistintos.Exists(x => x == int.Parse(item["Cliente"].ToString())))
+                                    {
+                                        listaClientesDistintos.Add(int.Parse(item["Cliente"].ToString()));
+                                    }
                                 }
                             }
                         }
-                    }
-                    try
-                    {
-                        if (listaClientesDistintos.Count > 0)
+                        try
                         {
-                            validarPeticion = true;
-                            ObtieneNombreCliente(listaClientesDistintos);
+                            if (listaClientesDistintos.Count > 0)
+                            {
+                                validarPeticion = true;
+                                ObtieneNombreCliente(listaClientesDistintos);
+                            }
+                            else
+                            {
+                                llenarListaEntrega();
+                            }
                         }
-                        else
+                        catch (Exception ex)
                         {
-                            llenarListaEntrega();
+                            throw ex;
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        throw ex;
                     }
                     return;
                 }

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Principal.master
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Principal.master
@@ -59,7 +59,7 @@
         </div>
         <div id="piePagina">
             <asp:Label ID="lblInformacion" runat="server" Width="100%" CssClass="etiqueta fg-color-blanco"></asp:Label>
-            <asp:Label runat="server" ID="lblVersion" Text="    Ver. 2.5.118"  CssClass="etiqueta fg-color-blanco"></asp:Label>
+            <asp:Label runat="server" ID="lblVersion" Text="    Ver. 2.5.119"  CssClass="etiqueta fg-color-blanco"></asp:Label>
         </div>
     </div>
     </form>

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Principal.master.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/Principal.master.cs
@@ -61,53 +61,60 @@ public partial class Principal : System.Web.UI.MasterPage
 
     protected void Page_Load(object sender, EventArgs e)
     {
-        if ((Session.Count > 0) && (operaciones == null))
+        try
         {
-            operaciones = (SeguridadCB.Public.Operaciones)HttpContext.Current.Session["Operaciones"];
-            //this.pnlTituloVisible = true;
-            this.lblInformacionGeneral = (string)HttpContext.Current.Session["PiePagina"];
-            this.smPathVisible = true;
-        }
-        
-        if (!Page.IsPostBack)
-        {
-            if (this.Request.UrlReferrer != null &&
-                (this.Request.UrlReferrer.ToString().ToUpper().Contains("MANUAL.ASPX") ||
-                this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX") ||
-                this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADCONCUERDA.ASPX") ||
-                this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADYREFERENCIACONCUERDA.ASPX") ||
-                this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX") ||
-                this.Request.UrlReferrer.ToString().ToUpper().Contains("VARIOSAUNO.ASPX")
-                ))
+            if ((Session.Count > 0) && (operaciones == null))
             {
-                if (! this.Request.UrlReferrer.ToString().Contains(Request.Url.AbsolutePath.ToString()))
-                {
-                    if (this.Request.UrlReferrer.ToString().ToUpper().Contains("MANUAL.ASPX"))
-                        LockerExterno.EliminarBloqueos(Session.SessionID, "MANUAL");
-                    else
-                    if (this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX"))
-                        LockerExterno.EliminarBloqueos(Session.SessionID, "UNOAVARIOS");
-                    else
-                    if (this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADCONCUERDA.ASPX"))
-                        LockerExterno.EliminarBloqueos(Session.SessionID, "CANTIDADCONCUERDA");
-                    else
-                    if (this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADYREFERENCIACONCUERDA.ASPX"))
-                        LockerExterno.EliminarBloqueos(Session.SessionID, "CANTIDADYREFERENCIACONCUERDA");
-                    else
-                    if (this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX"))
-                        LockerExterno.EliminarBloqueos(Session.SessionID, "UNOAVARIOS");
-                    else
-                    if (this.Request.UrlReferrer.ToString().ToUpper().Contains("VARIOSAUNO.ASPX"))
-                        LockerExterno.EliminarBloqueos(Session.SessionID, "VARIOSAUNO");
-                    //else
-                    //    LockerExterno.EliminarBloqueos(Session.SessionID);
-                }
+                operaciones = (SeguridadCB.Public.Operaciones)HttpContext.Current.Session["Operaciones"];
+                //this.pnlTituloVisible = true;
+                this.lblInformacionGeneral = (string)HttpContext.Current.Session["PiePagina"];
+                this.smPathVisible = true;
             }
+        
+            if (!Page.IsPostBack)
+            {
+                if (this.Request.UrlReferrer != null &&
+                    (this.Request.UrlReferrer.ToString().ToUpper().Contains("MANUAL.ASPX") ||
+                    this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX") ||
+                    this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADCONCUERDA.ASPX") ||
+                    this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADYREFERENCIACONCUERDA.ASPX") ||
+                    this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX") ||
+                    this.Request.UrlReferrer.ToString().ToUpper().Contains("VARIOSAUNO.ASPX")
+                    ))
+                {
+                    if (! this.Request.UrlReferrer.ToString().Contains(Request.Url.AbsolutePath.ToString()))
+                    {
+                        if (this.Request.UrlReferrer.ToString().ToUpper().Contains("MANUAL.ASPX"))
+                            LockerExterno.EliminarBloqueos(Session.SessionID, "MANUAL");
+                        else
+                        if (this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX"))
+                            LockerExterno.EliminarBloqueos(Session.SessionID, "UNOAVARIOS");
+                        else
+                        if (this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADCONCUERDA.ASPX"))
+                            LockerExterno.EliminarBloqueos(Session.SessionID, "CANTIDADCONCUERDA");
+                        else
+                        if (this.Request.UrlReferrer.ToString().ToUpper().Contains("CANTIDADYREFERENCIACONCUERDA.ASPX"))
+                            LockerExterno.EliminarBloqueos(Session.SessionID, "CANTIDADYREFERENCIACONCUERDA");
+                        else
+                        if (this.Request.UrlReferrer.ToString().ToUpper().Contains("UNOAVARIOS.ASPX"))
+                            LockerExterno.EliminarBloqueos(Session.SessionID, "UNOAVARIOS");
+                        else
+                        if (this.Request.UrlReferrer.ToString().ToUpper().Contains("VARIOSAUNO.ASPX"))
+                            LockerExterno.EliminarBloqueos(Session.SessionID, "VARIOSAUNO");
+                        //else
+                        //    LockerExterno.EliminarBloqueos(Session.SessionID);
+                    }
+                }
 
+            }
+        }
+        catch (Exception)
+        {
+            throw;
         }
     }
 
-    
+
 
     protected void menuPrincipal_MenuItemDataBound(object sender, MenuEventArgs e)
     {

--- a/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/ReportesConciliacion/ReporteEstadoCuenta.aspx.cs
+++ b/Conciliacion/App_Web/Sitio Conicliacion 07-07-2017/SitioConciliacion/ReportesConciliacion/ReporteEstadoCuenta.aspx.cs
@@ -201,7 +201,9 @@ public partial class ReportesConciliacion_ReporteEstadoCuenta : System.Web.UI.Pa
                         List<List<InformeBancarioDatos.DetalleReporteEstadoCuentaDia>> lstDetalle = new List<List<InformeBancarioDatos.DetalleReporteEstadoCuentaDia>>();
                         lstDetalle = consultaReporteEstadoCuentaDia("");
                         ExportadorInformeEstadoCuentaDia obExportador = new ExportadorInformeEstadoCuentaDia(
-                            lstDetalle, rutaCompleta, Archivo, "", btnlista.Text, DateTime.Parse(txtFInicial.Text), DateTime.Parse(txtFFinal.Text), usuario.NombreCorporativo);
+                            lstDetalle, rutaCompleta, Archivo, WUCListadoCuentasBancarias1.CuentasSeleccionadas[0].Descripcion, btnlista.Text, 
+                            DateTime.Parse(txtFInicial.Text), DateTime.Parse(txtFFinal.Text), 
+                            usuario.NombreCorporativo);
                         obExportador.generarInforme();       
                        
                         ScriptManager.RegisterStartupScript(this, typeof(Page), "UpdateMsg",


### PR DESCRIPTION
201: “En Conciliación » Reportes » Informes » Estado de cuenta, no sale la cuenat bancaria ni el banco, se anexa imagen”

202: “En Conciliación » Reportes » Informes » Estado de cuenta por día, sale un error al consultar elr eporte, se anexa imagen”

203: “En Conciliación » Reportes » Informes » Estado de cuenta conciliados, esta mal al suma de la etiqueta Retiro conciliado, ya que esta considerando un item QUE NO ESTA CONCILIADO”

205: “No se esta desconciliando en cantidad concuerda y referencia, al realizar la operación se desaparecen todos los registros conciliados y al actualizar nuevamente todos aparecen nuevamente”

206: “Se genera un mensaje de error al consultar el reporte de Estado de cuenta por día”